### PR TITLE
`build-spack-env.sh` from artutilscripts with history

### DIFF
--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1061,10 +1061,11 @@ fi
 if (( cache_write_bootstrap )); then \
   _report $PROGRESS "writing bootstrap packages to build cache"
   _cmd $DEBUG_1 spack \
-    ${__debug_spack_bootstrap:+-d} \
-    ${__verbose_spack_bootstrap:+-v} \
+    ${__debug_spack_buildcache:+-d} \
+    ${__verbose_spack_buildcache:+-v} \
     ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-    bootstrap mirror --binary-packages --dev "$working_dir/copyBack/spack-bootstrap-mirror" \
+    bootstrap mirror --binary-packages --dev \
+    "$working_dir/copyBack/spack-bootstrap-mirror" \
     || _report $WARNING "unable to write bootstrap packages to local cache"
 fi
 ####################################

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -710,7 +710,7 @@ _maybe_cache_binaries() {
 }
 
 _maybe_cache_sources() {
-  (( cache_write_sources )) || return
+  ! (( cache_write_sources )) && return
   local cache
   for cache in "$working_dir/copyBack/spack-packages/sources" \
                  ${extra_sources_write_cache[*]:+"${extra_sources_write_cache[@]}"}; do

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1042,18 +1042,6 @@ _cmd $DEBUG_1 spack buildcache keys
 ####################################
 
 ####################################
-# Execute bootstrap explicitly.
-_report $PROGRESS "bootstrapping Spack's tools"
-_cmd $PROGRESS $INFO \
-     spack \
-     ${__debug_spack_bootstrap:+-d} \
-     ${__verbose_spack_bootstrap:+-v} \
-     ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-     bootstrap now \
-  || _die $EXIT_BOOTSTRAP_FAILURE "unable to bootstrap safely with base configuration"
-####################################
-
-####################################
 # Initialize signing key for binary packages.
 if [ -n "$SPACK_BUILDCACHE_SECRET" ]; then
   _report $PROGRESS "initializing configured signing key"

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -76,6 +76,7 @@ BRIEF OPTIONS
   --color[= ](auto|always|never)
   --(debug|verbose)-spack-(bootstrap|buildcache|concretize|install)
   --(no-)?fail-fast
+  --(no-)?query-packages
   --(no-)?safe-concretize
   --spack-python[= ]<python-exec>
   --spack-config-cmd[= ]<config-cmd-string>+
@@ -195,6 +196,11 @@ SPACK CONFIGURATION OPTIONS
     Control whether to abort an installation at the first failure or
     continue to install as many packages as possible before exit
     (default --fail-fast).
+
+  --(no-)?query-packages
+
+    Construct a packages.yaml based on the packages available on the
+    system, or use a prepackaged one appropriate to the platform.
 
   --spack-python[= ]<python-exec>
 
@@ -1084,8 +1090,10 @@ while (( $# )); do
     --no-cache-write-binaries) _set_cache_write_binaries "none";;
     --no-cache-write-sources) unset cache_write_sources;;
     --no-fail-fast) unset fail_fast;;
+    --no-query-packages) unset query_packages;;
     --no-safe-concretize) unset concretize_safely;;
     --no-ups) ups_opt=-p;;
+    --query-packages) query_packages=1;;
     --quiet|-q) (( VERBOSITY = WARNING ));;
     --safe-concretize) concretize_safely=1;;
     --spack-config-cmd) spack_config_cmds+=("$2"); shift;;
@@ -1255,6 +1263,7 @@ if ! [ -f "$spack_env_top_dir/setup-env.sh" ]; then
     --minimal
     $ups_opt
   )
+  (( query_packages )) && make_spack_cmd+=(--query-packages)
   (( with_padding )) && make_spack_cmd+=(--with_padding)
   make_spack_cmd+=("$spack_env_top_dir")
   _report $PROGRESS "bootstrapping Spack $spack_ver"

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -930,7 +930,7 @@ if [[ "${spack_config_files[*]}" =~ (^|/)packages\.yaml([[:space:]]|$) ]]; then
 else
   # Don't want externals from CVMFS.
   _report $DEBUG_2 "externals in CVMFS will be excluded from generated packages.yaml"
-  _cmd $DEBUG_2 sed -Ei'' -e 's&^([[:space:]]+cprefix=).*$&\1'"''"'&' "$TMP/bin/make_packages_yaml"
+  _cmd $DEBUG_2 sed -Ei'' -e 's&^([[:space:]]+(cvmfsversions|cprefix)=).*$&\1'"''"'&' "$TMP/bin/make_packages_yaml"
 fi
 ####################################
 

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -464,7 +464,7 @@ _configure_spack() {
     config_file="${config_file##*'|'}"
     if [[ "$config_file" =~ ^[a-z][a-z0-9_-]*://(.*/)?(.*) ]]; then
       curl -o "${BASH_REMATCH[2]}" -fkLNSs "$config_file" \
-        || _die $EXIT_PATH_FAILURE "unable to obtain specified config file \"$config_file\""
+        || _die $EXIT_CONFIG_FAILURE "unable to obtain specified config file \"$config_file\""
       config_file="${BASH_REMATCH[2]}"
     fi
     _cmd $DEBUG_1 spack \
@@ -859,7 +859,7 @@ _process_environment() {
   local env_cfg="$1"
   if [[ "$env_cfg" =~ ^[a-z][a-z0-9_-]*://(.*/)?(.*) ]]; then
     curl -o "${BASH_REMATCH[2]}" -fkLNSs "$env_cfg" \
-      || _die $EXIT_PATH_FAILURE "unable to obtain specified environment config file \"$env_cfg\""
+      || _die $EXIT_CONFIG_FAILURE "unable to obtain specified environment config file \"$env_cfg\""
     env_cfg="${BASH_REMATCH[2]}"
   fi
   env_name="${env_cfg##*/}"

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -80,8 +80,8 @@ BRIEF OPTIONS
   --spack-python[= ]<python-exec>
   --spack-config-cmd[= ]<config-cmd-string>+
   --spack-config-file[= ](<cache-name>\|)?<config-file>+
-  --spack-infrastructure-root[= ]<repo>
-  --spack-infrastructure-version[= ]<version>
+  --fermi-spack-tools-root[= ]<repo>
+  --fermi-spack-tools-version[= ]<version>
   --spack-repo[= ]<path>|<repo>(\|<version|branch>)?
   --spack-root[= ]<repo>
   --spack-version[= ]<version>
@@ -136,11 +136,11 @@ HELP AND DIAGNOSTIC OPTIONS
 
 LOCATION AND VERSION OPTIONS
 
-  --spack-infrastructure-root[= ]<repo>
-  --spack-infrastructure-version[= ]<version|branch>
+  --fermi-spack-tools-root[= ]<repo>
+  --fermi-spack-tools-version[= ]<version|branch>
 
-    Obtain the Spack infrastructure utilities from the specified
-    repository and/or branch/version.
+    Obtain the Fermi Spack Tools from the specified repository and/or
+    branch/version.
 
   --spack-root[= ]<repo>
 
@@ -1043,7 +1043,7 @@ fi
 color=
 concretize_safely=1
 fail_fast=1
-si_root=https://github.com/FNALssi/spack-infrastructure.git
+si_root=https://github.com/FNALssi/fermi-spack-tools.git
 si_ver=master
 spack_ver=v0.19.0-dev.fermi
 spack_config_files=()
@@ -1086,10 +1086,10 @@ while (( $# )); do
     --spack-config-cmd=*) spack_config_cmds+=("${1#*=}");;
     --spack-config-file) spack_config_files+=("$2"); shift;;
     --spack-config-file=*) spack_config_files+=("${1#*=}");;
-    --spack-infrastructure-root) si_root="$2"; shift;;
-    --spack-infrastructure-root=*) si_root="${1#*=}";;
-    --spack-infrastructure-version) si_ver="$2"; shift;;
-    --spack-infrastructure-version=*) si_ver="${1#*=}";;
+    --fermi-spack-tools-root) si_root="$2"; shift;;
+    --fermi-spack-tools-root=*) si_root="${1#*=}";;
+    --fermi-spack-tools-version) si_ver="$2"; shift;;
+    --fermi-spack-tools-version=*) si_ver="${1#*=}";;
     --spack-python) spack_python="$2"; shift;;
     --spack-python=*) spack_python="${1#*=}";;
     --spack-repo) recipe_repos+=("$2"); shift;;
@@ -1220,10 +1220,10 @@ exec $STDOUT>&- $STDERR>&-\
 
 si_upsver="v${si_ver#v}"
 ####################################
-# Install spack-infrastructure to bootstrap a Spack installation.
-_report $PROGRESS "cloning spack-infrastructure"
+# Install fermi-spack-tools to bootstrap a Spack installation.
+_report $PROGRESS "cloning fermi-spack-tools"
 _cmd $DEBUG_1 git clone -b "$si_ver" "$si_root" "$TMP/" \
-  || _die "unable to clone spack-infrastructure $si_ver from $si_root"
+  || _die "unable to clone fermi-spack-tools $si_ver from $si_root"
 if [[ "${spack_config_files[*]}" =~ (^|/)packages\.yaml([[:space:]]|$) ]]; then
   # Bypass packages.yaml generation if we're going to ignore it anyway.
   _report $DEBUG_2 "bypassing packages.yaml generation"
@@ -1287,7 +1287,7 @@ IFS="$OIFS"
 ####################################
 # Set up the build environment.
 if ! [ "$ups_opt" = "-p" ]; then
-  _report $PROGRESS "declaring spack-infrastructure package to UPS"
+  _report $PROGRESS "declaring fermi-spack-tools package to UPS"
   { source /grid/fermiapp/products/common/etc/setups \
       || source /products/setup \
       || _die $EXIT_UPS_ERROR "unable to set up UPS"
@@ -1296,10 +1296,10 @@ if ! [ "$ups_opt" = "-p" ]; then
 
   cd $TMP \
     && {
-    _cmd $DEBUG_1 ups exist spack-infrastructure $si_upsver \
-      || _cmd $DEBUG_1 "$TMP/bin/declare_simple" spack-infrastructure $si_upsver
+    _cmd $DEBUG_1 ups exist fermi-spack-tools $si_upsver \
+      || _cmd $DEBUG_1 "$TMP/bin/declare_simple" fermi-spack-tools $si_upsver
   } \
-    || _die $EXIT_UPS_ERROR "unable to declare spack-infrastructure $si_ver to UPS"
+    || _die $EXIT_UPS_ERROR "unable to declare fermi-spack-tools $si_ver to UPS"
   cd - >/dev/null
 fi
 ####################################

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -94,6 +94,7 @@ BRIEF OPTIONS
   --ups[= ](plain|traditional|unified|-[ptu])
   --with-cache[= ](<cache-name>\|)?|<cache-path>|<cache-url>)(,...)+
   --with-concretiz(e|ing|ation)-cache[= ](<cache-name>\|)?|<cache-path>|<cache-url>)(,...)+
+  --with-padding
   --working-dir[= ]<dir>
 
   [ Options suffixed with + are repeatable and cumulative ]
@@ -230,6 +231,10 @@ SPACK CONFIGURATION OPTIONS
     Create and populate a traditional, unified ("relocatable") or no UPS
     area to allow the use of installed Spack packages via UPS. Default
     is unified.
+
+  --with-padding
+
+    Equivalent to --spack-config-cmd='--scope=site add config:install_tree:padded_length:255'
 
 
 NON-OPTION ARGUMENTS
@@ -1122,6 +1127,7 @@ while (( $# )); do
       optarg="${1#*=}"; OIFS="$IFS"; IFS=","
       concretizing_cache_specs+=($optarg); IFS="$OIFS"
       ;;
+    --with-padding) with_padding=1;;
     --working-dir=*) working_dir="${1#*=}";;
     --working_dir) working_dir="$2"; shift;;
     --) shift; break;;
@@ -1247,8 +1253,9 @@ if ! [ -f "$spack_env_top_dir/setup-env.sh" ]; then
     --spack_release $spack_ver
     --minimal
     $ups_opt
-    "$spack_env_top_dir"
   )
+  (( with_padding )) && make_spack_cmd+=(--with_padding)
+  make_spack_cmd+=("$spack_env_top_dir")
   _report $PROGRESS "bootstrapping Spack $spack_ver"
   PATH="$TMP/bin:$PATH" \
       _cmd $PROGRESS ${make_spack_cmd[*]:+"${make_spack_cmd[@]}"} \

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -567,7 +567,7 @@ while (( $# )); do
     --no-cache-write-sources) unset cache_write_sources;;
     --no-safe-concretize) unset concretize_safely;;
     --no-ups) ups_opt=-p;;
-    --quiet|-q) QUIET=1;;
+    --quiet|-q) (( VERBOSITY = WARNING ));;
     --safe-concretize) concretize_safely=1;;
     --spack-config-cmd) spack_config_cmds+=("$2"); shift;;
     --spack-config-cmd=*) spack_config_cmds+=("${1#*=}");;
@@ -587,7 +587,10 @@ while (( $# )); do
     --test=*) tests_type="${1#*=}";;
     --ups) ups_opt="$(_ups_string_to_opt "$2")" || exit; shift;;
     --ups=*) ups_opt="$(_ups_string_to_opt "${1#*=}")" || exit;;
+    +v) (( --VERBOSITY ));;
     -v) (( ++VERBOSITY ));;
+    --verbosity) eval "(( VERBOSITY = $2 ))"; shift;;
+    --verbosity=*) eval "(( VERBOSITY = ${1#*=} ))";;
     --with-cache) optarg="$2"; shift; OIFS="$IFS"; IFS=","; cache_urls+=($optarg); IFS="$OIFS";;
     --with-cache=*) optarg="${1#*=}"; OIFS="$IFS"; IFS=","; cache_urls+=($optarg); IFS="$OIFS";;
     --working-dir=*) working_dir="${1#*=}";;
@@ -607,15 +610,6 @@ else
   unset want_color
 fi
 common_spack_opts+=($color_arg)
-
-####################################
-# Supress all but warnings and errors if we need quiet.
-if (( QUIET )); then
-  (( VERBOSITY > DEFAULT_VERBOSITY )) && _report $INFO "-q overrides -v"
-  (( VERBOSITY = WARNING ))
-fi
-####################################
-
 
 ####################################
 # Set up working area.

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -335,11 +335,11 @@ _config_recipe_repos() {
       local url=
       local url_type="${BASH_REMATCH[1]}"
       local url_remainder="${BASH_REMATCH[2]}"
-      local branch_etc="${url_remainder##*:}"
+      local branch_etc="${url_remainder##*|}"
       if [ "$branch_etc" = "$url_remainder" ]; then
         url="$url_type://$url_remainder"
       else
-        url="$url_type://${url_remainder%:*}"
+        url="$url_type://${url_remainder%|*}"
       fi
       local path="${url%.git}" rpath=
       path="$SPACK_ROOT/${path##*/}"

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -627,7 +627,7 @@ _process_environment() {
     compiler_path="$( ( spack \
                     -e $env_name \
                      ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-                     location --install-dir "$env_spec" ) )" \
+                     location --install-dir "${env_spec/clang/llvm}" ) )" \
       || _die $EXIT_PATH_FAILURE "failed to extract path info for new compiler $env_spec"
     _report $DEBUG_1 "registering compiler at $compiler_path with Spack"
     _cmd $DEBUG_1 spack \

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -767,7 +767,7 @@ _maybe_register_compiler() {
       local compilers_yaml="$(_cmd $DEBUG_2 $PIPE spack \
                      ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
                      config --scope site edit --print-file compilers)"
-      _cmd $DEBUG_2 perl -wapi'' -e 'm&\bcompiler:\s*$&msx and $in_compiler=1; $in_compiler and m&spec:\s*\Q'"$compiler_spec"'\E&msx and $in_wanted_compiler=1; $in_wanted_compiler and s&(^\s*environment:\s*).*$&$1\{ prepend_path: \{ PATH: "'"$binutils_path"'/bin" \} \}\n&msx and undef $in_wanted_compiler and undef $in_compiler' "$compilers_yaml" || _die $EXIT_PATH_FAILURE "unable to configure compiler binutils path"
+      _cmd $DEBUG_2 perl -wapi'' -e 'm&\bcompiler:\s*$&msx and $in_compiler=1; $in_compiler and m&spec:\s*\Q'"$compiler_spec"'\E&msx and $in_wanted_compiler=1; $in_wanted_compiler and s&(^\s*environment:\s*).*$&$1\{ prepend_path: \{ PATH: "'"$binutils_path"'/bin" \} \}\n&msx and undef $in_wanted_compiler and undef $in_compiler' "$compilers_yaml" || _die $EXIT_SPACK_CONFIG_FAILURE "unable to configure compiler binutils path for $compiler_spec"
     fi
   fi
 }

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -336,8 +336,8 @@ _copy_back_logs() {
         | _cmd $DEBUG_1 tar -C "$tar_tmp/installed/$env_spec" -x
     fi
   done
-  _cmd $DEBUG_1 $PIPE tar -C "$tar_tmp" -jcf "$working_dir/copyBack/${BUILD_TAG:-spack-output}.tar.bz2" .
-  _debug $DEBUG_1 rm -rf "$tar_tmp"
+  _cmd $DEBUG_1 tar -C "$tar_tmp" -jcf "$working_dir/copyBack/${BUILD_TAG:-spack-output}.tar.bz2" .
+  _cmd $DEBUG_1 rm -rf "$tar_tmp"
 } 2>/dev/null
 
 # Print a message and exit with the specifed numeric first argument or 1

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -383,7 +383,7 @@ _classify_concretized_specs() {
   OIFS="$IFS"; IFS=$'\n'; root_hashes=($(echo "${root_hashes[*]}" | sort -u)); IFS="$OIFS"
   _report $DEBUG_2 "root_hashes=\n             ${root_hashes[@]/%/$'\n'  }"
   idx=${#hashes[@]}
-  local n_unique=$(IFS=$'\n' echo "${hashes[*]}" | sort -u | wc -l)
+  local n_unique=$(IFS=$'\n'; echo "${hashes[*]}" | sort -u | wc -l)
   _report $DEBUG_1 "examined $specline_idx speclines and found ${#root_hashes[@]} roots and $n_unique packages"
 }
 

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -923,11 +923,6 @@ _process_environment() {
 }
 
 # Properly quote a message for protection from the shell if copy/pasted.
-if (( ${BASH_VERSINFO[0]} > 4 )) \
-     || { (( ${BASH_VERSINFO[0]} == 4 )) \
-            && (( ${BASH_VERSINFO[1]} >= 4 )); }; then
-_quote() { local result_var="$1"; shift; eval $result_var='"${*@Q}"'; }
-else
 _quote() {
   local x= result_var="$1" result=()
   shift
@@ -941,7 +936,6 @@ _quote() {
   done
   eval $result_var='"${result[*]}"'
 }
-fi
 
 _remove_hash() {
   local hashes_var="$1" handled_hash="$2"

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -769,6 +769,9 @@ _maybe_register_compiler() {
                      config --scope site edit --print-file compilers)"
       _cmd $DEBUG_2 perl -wapi'' -e 'm&\bcompiler:\s*$&msx and $in_compiler=1; $in_compiler and m&spec:\s*\Q'"$compiler_spec"'\E&msx and $in_wanted_compiler=1; $in_wanted_compiler and s&(^\s*environment:\s*).*$&$1\{ prepend_path: \{ PATH: "'"$binutils_path"'/bin" \} \}\n&msx and undef $in_wanted_compiler and undef $in_compiler' "$compilers_yaml" || _die $EXIT_SPACK_CONFIG_FAILURE "unable to configure compiler binutils path for $compiler_spec"
     fi
+    if [[ "$compiler_spec" == *clang* ]]; then
+      _cmd $DEBUG_2 perl -wapi'' -e 'm&\bcompiler:\s*$&msx and $in_compiler=1; $in_compiler and m&spec:\s*\Q'"$compiler_spec"'\E&msx and $in_wanted_compiler=1; $in_wanted_compiler and s&(^\s*flags:\s*).*$&$1\{ cxxflags: -stdlib=libc++ \}\n&msx and undef $in_wanted_compiler and undef $in_compiler' "$compilers_yaml" || _die $EXIT_SPACK_CONFIG_FAILURE "unable to configure compiler flags for $compiler_spec"
+    fi
   fi
 }
 

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -699,6 +699,7 @@ _maybe_cache_sources() {
        -e $env_name \
        ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
        mirror create -aD --skip-unstable-versions -d "$cache"
+  done
 }
 
 _maybe_register_compiler() {

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1300,7 +1300,7 @@ if (( failed == 1 )) && [ \"${cache_write_binaries:-none}\" != none ]; then \
       \${buildcache_key_opts[*]:+\"\${buildcache_key_opts[@]}\"} \
       \$buildcache_rel_arg --rebuild-index \
       \"$working_dir/copyBack/spack-emergency-cache\" \
-      \$(spack find --no-groups); \
+      \$(spack find -L | sed -Ene 's&^([[:alnum:]]+).*\$&/\\1&p'); \
   tag_text=ALERT _report $ERROR \"emergency buildcache dump COMPLETE\"; \
 fi; \
 exec $STDOUT>&- $STDERR>&-\

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -449,7 +449,7 @@ _configure_spack() {
   _report $PROGRESS "applying user-specified Spack configuration commands"
   local config_cmd
   for config_cmd in ${spack_config_cmds[*]:+"${spack_config_cmds[@]}"}; do
-    eval _cmd $DEBUG_1 spack \
+    _cmd $DEBUG_1 spack \
          ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
          config $config_cmd \
       || _die $EXIT_SPACK_CONFIG_FAILURE "executing spack config command \"$config_cmd\""

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -456,6 +456,7 @@ _do_build_and_test() {
     ${common_spack_opts[*]:+"${common_spack_opts[@]}"}
     install
     ${fail_fast:+--fail-fast}
+    --no-add
     --only-concrete
     ${extra_install_opts[*]:+"${extra_install_opts[@]}"}
   )

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -606,11 +606,10 @@ _process_environment() {
         _report $DEBUG_1 "removing package for root spec $spec from binary cache"
         _cmd $DEBUG_1 \
              find "$working_dir/copyBack/spack-$binary_mirror-cache" \
-             \( -type d -empty \) -o \
+             -d \
              \( -type f \
                 \( -name "$spec.spack" -o -name "$spec.spec.json" -o -name "$spec.spec.json.sig" \) \
-             \) \
-             -delete
+             \) -o \( -type d -empty \) -delete
       done
     fi  >/dev/null 2>&1
     _report $PROGRESS "updating local build cache index"

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -716,7 +716,7 @@ fi
 # Clear mirrors list back to defaults.
 if (( clear_mirrors )); then
   _report $PROGRESS "clearing default mirrors list"
-  _cmd $PROGRESS "$default_mirrors" "$mirrors_cfg"
+  _cmd $PROGRESS cp "$default_mirrors" "$mirrors_cfg"
 fi
 
 # Enhanced setup scripts.

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -515,13 +515,13 @@ _make_concretize_mirrors_yaml() {
     && cp "$default_mirrors" "$mirrors_cfg" \
     && spack \
          ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-         mirror add --scope=site __local_binaries "file://$working_dir/copyBack/spack-binary-cache" \
+         mirror add --scope=site __local_binaries "$working_dir/copyBack/spack-binary-cache" \
     && spack \
          ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-         mirror add --scope=site __local_compilers "file://$working_dir/copyBack/spack-compiler-cache" \
+         mirror add --scope=site __local_compilers "$working_dir/copyBack/spack-compiler-cache" \
     && spack \
          ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-         mirror add --scope=site __local_sources "file://$working_dir/copyBack/spack-source-cache" \
+         mirror add --scope=site __local_sources "$working_dir/copyBack/spack-source-cache" \
     && cp "$mirrors_cfg" "$out_file" \
     && mv -f "$mirrors_cfg"{~,} \
       || _die $EXIT_SPACK_CONFIG_FAILURE "unable to generate concretization-specific mirrors.yaml at \"$out_file\""
@@ -661,7 +661,7 @@ _process_environment() {
                 _cmd $DEBUG_1 $PROGRESS spack \
                      -e $env_name \
                      ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-                     mirror create -aD --skip-unstable-versions -d "$working_dir/copyBack/spack-source-cache"
+                     mirror create -aD --skip-unstable-versions "$working_dir/copyBack/spack-source-cache"
          }
     } \
       && _do_build_and_test \
@@ -694,8 +694,8 @@ _process_environment() {
            buildcache create -a --deptype=all \
            ${buildcache_package_opts[*]:+"${buildcache_package_opts[@]}"} \
            ${buildcache_key_opts[*]:+"${buildcache_key_opts[@]}"} \
-           -d "$working_dir/copyBack/spack-$binary_mirror-cache" \
-           -r --spec-file "$env_json"
+           -r --spec-file "$env_json" \
+           "$working_dir/copyBack/spack-$binary_mirror-cache"
     done
     if [ "$cache_write_binaries" = "no_roots" ] && ! (( is_compiler_env )); then
       _report $PROGRESS "removing roots of environment $env_name from binary cache"
@@ -1015,8 +1015,9 @@ if (( failed == 1 )) && [ \"${cache_write_binaries:-none}\" != none ]; then \
       \${common_spack_opts[*]:+\"\${common_spack_opts[@]}\"} \
       buildcache create -a --deptype=all \
       \${buildcache_key_opts[*]:+\"\${buildcache_key_opts[@]}\"} \
-      -d \"$working_dir/copyBack/spack-emergency-cache\" \
-      -r --rebuild-index \$(spack find --no-groups); \
+      -r --rebuild-index \
+      \"$working_dir/copyBack/spack-emergency-cache\" \
+      \$(spack find --no-groups); \
   tag_text=ALERT _report $ERROR \"emergency buildcache dump COMPLETE\"; \
 fi; \
 exec $STDOUT>&- $STDERR>&-\
@@ -1127,10 +1128,10 @@ done
 _config_recipe_repos
 
 # Add mirror as buildcache for locally-built packages.
-_cmd $DEBUG_1 spack mirror add --scope=site __local_binaries "file://$working_dir/copyBack/spack-binary-cache"
-_cmd $DEBUG_1 spack mirror add --scope=site __local_bootstrap "file://$working_dir/copyBack/spack-bootstrap-cache"
-_cmd $DEBUG_1 spack mirror add --scope=site __local_compilers "file://$working_dir/copyBack/spack-compiler-cache"
-_cmd $DEBUG_1 spack mirror add --scope=site __local_sources "file://$working_dir/copyBack/spack-source-cache"
+_cmd $DEBUG_1 spack mirror add --scope=site __local_binaries "$working_dir/copyBack/spack-binary-cache"
+_cmd $DEBUG_1 spack mirror add --scope=site __local_bootstrap "$working_dir/copyBack/spack-bootstrap-cache"
+_cmd $DEBUG_1 spack mirror add --scope=site __local_compilers "$working_dir/copyBack/spack-compiler-cache"
+_cmd $DEBUG_1 spack mirror add --scope=site __local_sources "$working_dir/copyBack/spack-source-cache"
 
 # Make a cut-down mirror configuration for safe concretization.
 if (( concretize_safely )); then

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -279,13 +279,13 @@ CACHING SOURCE AND BINARY PACKAGES
   If configured:
 
   * Source packages for each environment will be cached under
-    `<working-dir>/copyBack/spack-source-cache` before that environment
+    `<working-dir>/copyBack/spack-packages/sources` before that environment
     is built. "Non-stable" sources (e.g. those obtained from
     repositories) will not be cached.
 
   * Binary packages for each environment will be cached under
-    `<working-dir>/copyBack/spack-binary-cache` or
-    `<working-dir>/copyBack/spack-compiler-cache` (as appropriate) after
+    `<working-dir>/copyBack/spack-packages/binaries` or
+    `<working-dir>/copyBack/spack-packages/compilers` (as appropriate) after
     that environment has been built successfully. If
     `--cache-write-binaries=no_root` is active, then root packages of
     non-compiler environments will not be cached.
@@ -710,9 +710,9 @@ _maybe_cache_binaries() {
 }
 
 _maybe_cache_sources() {
-  (( cache_write_sources )) && return
+  (( cache_write_sources )) || return
   local cache
-  for cache in "$working_dir/copyBack/spack-source-cache" \
+  for cache in "$working_dir/copyBack/spack-packages/sources" \
                  ${extra_sources_write_cache[*]:+"${extra_sources_write_cache[@]}"}; do
     _report $PROGRESS "caching sources in mirror $cache"
   _cmd $DEBUG_1 $PROGRESS spack \
@@ -1159,9 +1159,9 @@ fi
 
 # Local cache locations are derived from $working_dir.
 local_caches=(
-  "__local_binaries|$working_dir/copyBack/spack-binary-cache"
-  "__local_compilers|$working_dir/copyBack/spack-compiler-cache"
-  "__local_sources|$working_dir/copyBack/spack-source-cache"
+  "__local_binaries|$working_dir/copyBack/spack-packages/binaries"
+  "__local_compilers|$working_dir/copyBack/spack-packages/compilers"
+  "__local_sources|$working_dir/copyBack/spack-packages/sources"
 )
 
 spack_env_top_dir="$working_dir/spack_env"

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -621,9 +621,9 @@ _process_environment() {
   ####################################
 
   ####################################
-  # If we just built a non-terminal compiler environment, add the
+  # If we just built a compiler environment, add the
   # compiler to the list of available compilers.
-  if (( is_nonterminal_compiler_env )); then
+  if (( is_compiler_env )); then
     compiler_path="$( ( spack \
                     -e $env_name \
                      ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -595,7 +595,6 @@ while (( $# )); do
     --with-cache=*) optarg="${1#*=}"; OIFS="$IFS"; IFS=","; cache_urls+=($optarg); IFS="$OIFS";;
     --working-dir=*) working_dir="${1#*=}";;
     --working_dir) working_dir="$2"; shift;;
-    -h) usage; exit 1;;
     --) shift; break;;
     -*) _die $EXIT_CONFIG_FAILURE "unrecognized option $1\n$(usage)";;
     *) break

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -144,7 +144,7 @@ LOCATION AND VERSION OPTIONS
 
   --spack-root[= ]<repo>
 
-    [ NOT CURRENTLY SUPPORTED due to limitations in downstream utilities ]
+    Obtain Spack from the specified repository.
 
   --spack-version[= ]<version|branch>
 
@@ -1241,7 +1241,14 @@ mkdir -p "$spack_env_top_dir" \
   || _die $EXIT_PATH_FAILURE "unable to make directory structure for spack environment installation"
 cd "$spack_env_top_dir"
 if ! [ -f "$spack_env_top_dir/setup-env.sh" ]; then
-  make_spack_cmd=(make_spack --spack_release $spack_ver --minimal $ups_opt "$spack_env_top_dir")
+  make_spack_cmd=(
+    make_spack
+    ${spack_root:+--spack_repo "$spack_root"}
+    --spack_release $spack_ver
+    --minimal
+    $ups_opt
+    "$spack_env_top_dir"
+  )
   _report $PROGRESS "bootstrapping Spack $spack_ver"
   PATH="$TMP/bin:$PATH" \
       _cmd $PROGRESS ${make_spack_cmd[*]:+"${make_spack_cmd[@]}"} \

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1049,6 +1049,10 @@ SPACK_ROOT=$SPACK_ROOT
 $(spack env status)"
 fi
 
+# Temporary working area (and cleanup trap).
+TMP=`mktemp -d -t build-spack-env.sh.XXXXXX`
+trap "[ -d \"$TMP\" ] && rm -rf \"$TMP\" 2>/dev/null" EXIT
+
 ########################################################################
 # To split bundled single-option arguments in your function or script:
 #
@@ -1291,7 +1295,6 @@ _configure_spack
 
 ####################################
 # Safe, comprehensive cleanup.
-TMP=`mktemp -d -t build-spack-env.sh.XXXXXX`
 trap "[ -d \"$TMP\" ] && rm -rf \"$TMP\" 2>/dev/null; \
 [ -f \"\$mirrors_cfg~\" ] && mv -f \"\$mirrors_cfg\"{~,}; \
 _copy_back_logs; \

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -473,11 +473,11 @@ _severity_tag() {
     fi
   fi
   case $1 in
-    $ERROR) tag="\e[1;31m==> ${tag_text:-${DIE_ERROR:+$DIE_ERROR }ERROR}\e[m";;
-    $WARNING) tag="\e[1;33m==> ${tag_text:-WARNING}\e[m";;
-    $INFO) tag="\e[1;34m==> ${tag_text:-INFO}\e[m";;
-    $PROGRESS) tag="\e[1;32m==> ${tag_text:-PROGRESS}\e[m";;
-    *) tag="\e[1m==> ${tag_text:-DEBUG_$(( $1 - DEBUG_0 ))}\e[m"
+    $ERROR) tag="${want_color:+\e[1;31m}==> ${tag_text:-${DIE_ERROR:+$DIE_ERROR }ERROR}${want_color:+\e[m}";;
+    $WARNING) tag="${want_color:+\e[1;33m}==> ${tag_text:-WARNING}${want_color:+\e[m}";;
+    $INFO) tag="${want_color:+\e[1;34m}==> ${tag_text:-INFO}${want_color:+\e[m}";;
+    $PROGRESS) tag="${want_color:+\e[1;32m}==> ${tag_text:-PROGRESS}${want_color:+\e[m}";;
+    *) tag="${want_color:+\e[1m}==> ${tag_text:-DEBUG_$(( $1 - DEBUG_0 ))}${want_color:+\e[m}"
   esac
   echo "$tag"
 }
@@ -601,6 +601,11 @@ while (( $# )); do
 done
 
 color_arg=${color:+--color=$color}
+if [ "${color:-auto}" = "auto" -a -t 1 ] || [ "$color" = "always" ]; then
+  want_color=1
+else
+  unset want_color
+fi
 common_spack_opts+=($color_arg)
 
 ####################################

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -169,6 +169,10 @@ SPACK CONFIGURATION OPTIONS
 
   --(no-)?fail-fast
 
+    Control whether to abort an installation at the first failure or
+    continue to install as many packages as possible before exit
+    (default --fail-fast).
+
   --(no-)?safe-concretize
 
     Control whether to concretize environments with only a minimal set

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -100,7 +100,7 @@ BRIEF OPTIONS
   [ Options suffixed with + are repeatable and cumulative ]
 
 EOF
-  if (( "$1" == 0 )); then
+  if (( "${1:-0}" == 0 )); then
     return
   fi
 cat <<\EOF

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -155,6 +155,8 @@ LOCATION AND VERSION OPTIONS
 
 SPACK CONFIGURATION OPTIONS
 
+ Mirror/Cache Options
+
   --cache-write-(sources|binaries[= ](all|none|deps|dependencies|(no|non)[_-]roots|roots))
   --no-cache-write-(sources|binaries)
 
@@ -162,21 +164,27 @@ SPACK CONFIGURATION OPTIONS
     caches under <working-dir>/copyBack.
 
   --clear-mirrors
+
+    Remove bootstrapped mirrors/caches from configuration.
+
   --with-cache[= ](<cache-name>\|)?|<cache-path>|<cache-url>)(,...)+
 
-    Control the use of mirrors from which to obtain sources and/or
-    pre-built binary packages.
+    Add a read-only mirror/cache. If --safe-concretize is set, added
+    caches will be ignored during the concretizaton process.
+
+
+ Other Spack Configuration
+
+  --(no-)?safe-concretize
+
+    Control whether to concretize environments with only a minimal set
+    of mirrors configured to improve reproducibility (default yes).
 
   --(no-)?fail-fast
 
     Control whether to abort an installation at the first failure or
     continue to install as many packages as possible before exit
     (default --fail-fast).
-
-  --(no-)?safe-concretize
-
-    Control whether to concretize environments with only a minimal set
-    of mirrors configured to improve reproducibility (default yes).
 
   --spack-python[= ]<python-exec>
 

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1050,11 +1050,6 @@ spack_config_files=()
 spack_config_cmds=()
 recipe_repos=()
 cache_specs=()
-local_caches=(
-  "__local_binaries|$working_dir/copyBack/spack-binary-cache"
-  "__local_compilers|$working_dir/copyBack/spack-compiler-cache"
-  "__local_sources|$working_dir/copyBack/spack-source-cache"
-)
 concretizing_cache_specs=()
 extra_sources_write_cache=()
 extra_binaries_write_cache=()
@@ -1155,6 +1150,13 @@ if [ -z "$TMPDIR" ]; then
   mkdir -p "$TMPDIR"
 fi
 ####################################
+
+# Local cache locations are derived from $working_dir.
+local_caches=(
+  "__local_binaries|$working_dir/copyBack/spack-binary-cache"
+  "__local_compilers|$working_dir/copyBack/spack-compiler-cache"
+  "__local_sources|$working_dir/copyBack/spack-source-cache"
+)
 
 spack_env_top_dir="$working_dir/spack_env"
 

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1229,11 +1229,13 @@ fi
 # Enhanced setup scripts.
 if [ "$ups_opt" = "-p" ]; then
   cat >setup-env.sh <<EOF
+export PATH="$(echo "$PATH" | sed -Ee 's&(^|:)[^/][^:]*&&g')"
 . "$spack_env_top_dir/share/spack/setup-env.sh"
 export SPACK_DISABLE_LOCAL_CONFIG=true
 export SPACK_USER_CACHE_PATH="$spack_env_top_dir/tmp/spack-cache"
 EOF
   cat >setup-env.csh <<EOF
+setenv PATH "`echo "$PATH" | sed -Ee 's&(^|:)[^/][^:]*&&g'`"
 source "$spack_env_top_dir/share/spack/setup-env.csh"
 setenv SPACK_DISABLE_LOCAL_CONFIG true
 setenv SPACK_USER_CACHE_PATH "$spack_env_top_dir/tmp/spack-cache"

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -488,7 +488,7 @@ _piecemeal_build() {
 _process_environment() {
   local env_cfg="$1"
   if [[ "$env_cfg" =~ ^[a-z][a-z0-9_-]*://(.*/)?(.*) ]]; then
-    curl -o "${BASH_REMATCH[2]}" -N --no-progress-meter --insecure --fail -L "$env_cfg" \
+    curl -o "${BASH_REMATCH[2]}" -fkLNSs "$env_cfg" \
       || _die $EXIT_PATH_FAILURE "unable to obtain specified environment config file \"$env_cfg\""
     env_cfg="${BASH_REMATCH[2]}"
   fi
@@ -976,7 +976,7 @@ for config_file in ${spack_config_files[*]:+"${spack_config_files[@]}"}; do
   [ "$cf_scope" = "$config_file" ] && cf_scope=site
   config_file="${config_file##*'|'}"
   if [[ "$config_file" =~ ^[a-z][a-z0-9_-]*://(.*/)?(.*) ]]; then
-    curl -o "${BASH_REMATCH[2]}" -N --no-progress-meter --insecure --fail -L "$config_file" \
+    curl -o "${BASH_REMATCH[2]}" -fkLNSs "$config_file" \
       || _die $EXIT_PATH_FAILURE "unable to obtain specified config file \"$config_file\""
     config_file="${BASH_REMATCH[2]}"
   fi

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -634,7 +634,7 @@ _make_concretize_mirrors_yaml() {
       || _die $EXIT_SPACK_CONFIG_FAILURE "unable to generate concretization-specific mirrors.yaml at \"$out_file\""
 }
 
-_maybe_cache_sources() {
+_maybe_cache_binaries() {
   [ "${cache_write_binaries:-none}" == "none" ] && return
   local binary_mirror= hashes_to_cache=() msg_extra=
   if (( is_compiler_env )); then

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1045,9 +1045,7 @@ _cmd $DEBUG_1 spack buildcache keys
 # Initialize signing key for binary packages.
 if [ -n "$SPACK_BUILDCACHE_SECRET" ]; then
   _report $PROGRESS "initializing configured signing key"
-  spack \
-    ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-    gpg trust "$SPACK_BUILDCACHE_SECRET"
+  spack gpg trust "$SPACK_BUILDCACHE_SECRET" >/dev/null 2>&1
   # Handle older Spack installations that need the long-format keyid.
   keyid="$(gpg2 --list-secret-keys --keyid-format long --homedir "${SPACK_GNUPGHOME:-$SPACK_ROOT/opt/spack/gpg}" | sed -Ene '/^sec/{s&^[^/]+/([A-F0-9]+).*$&\1&p; q}')"
   buildcache_key_opts+=(--key "$keyid")

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -333,9 +333,11 @@ _process_environment() {
                 _cmd $DEBUG_1 $PROGRESS spack \
                      -e $env_name \
                      ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-                     mirror create -aD --skip-unstable-versions -d "$working_dir/copyBack/spack-source-mirror"; }; } \
-                  && _do_build_and_test \
-                    || failed=1
+                     mirror create -aD --skip-unstable-versions -d "$working_dir/copyBack/spack-source-mirror"
+         }
+    } \
+      && _do_build_and_test \
+        || failed=1
   if [ -n "$interrupt" ]; then
     failed=1 # Trigger buildcache dump.
     local tag_text=ALERT

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -431,13 +431,13 @@ _make_concretize_mirrors_yaml() {
     && cp "$default_mirrors" "$mirrors_cfg" \
     && spack \
          ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-         mirror add --scope=site __local_binaries "$working_dir/copyBack/spack-binary-cache" \
+         mirror add --scope=site __local_binaries "file://$working_dir/copyBack/spack-binary-cache" \
     && spack \
          ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-         mirror add --scope=site __local_compilers "$working_dir/copyBack/spack-compiler-cache" \
+         mirror add --scope=site __local_compilers "file://$working_dir/copyBack/spack-compiler-cache" \
     && spack \
          ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-         mirror add --scope=site __local_sources "$working_dir/copyBack/spack-source-cache" \
+         mirror add --scope=site __local_sources "file://$working_dir/copyBack/spack-source-cache" \
     && cp "$mirrors_cfg" "$out_file" \
     && mv -f "$mirrors_cfg"{~,} \
       || _die $EXIT_SPACK_CONFIG_FAILURE "unable to generate concretization-specific mirrors.yaml at \"$out_file\""
@@ -1012,6 +1012,7 @@ for cache_spec in ${cache_urls[*]:+"${cache_urls[@]}"}; do
   else
     cache_name="buildcache_$((++cache_count))"
   fi
+  [ "${cache_spec: 0:1}" = "/" ] && cache_spec="file://$cache_spec"
   _cmd $DEBUG_1 spack \
     ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
     mirror add --scope=site "$cache_name" "$cache_spec" \
@@ -1019,10 +1020,10 @@ for cache_spec in ${cache_urls[*]:+"${cache_urls[@]}"}; do
 done
 
 # Add mirror as buildcache for locally-built packages.
-_cmd $DEBUG_1 spack mirror add --scope=site __local_binaries "$working_dir/copyBack/spack-binary-cache"
-_cmd $DEBUG_1 spack mirror add --scope=site __local_bootstrap "$working_dir/copyBack/spack-bootstrap-cache"
-_cmd $DEBUG_1 spack mirror add --scope=site __local_compilers "$working_dir/copyBack/spack-compiler-cache"
-_cmd $DEBUG_1 spack mirror add --scope=site __local_sources "$working_dir/copyBack/spack-source-cache"
+_cmd $DEBUG_1 spack mirror add --scope=site __local_binaries "file://$working_dir/copyBack/spack-binary-cache"
+_cmd $DEBUG_1 spack mirror add --scope=site __local_bootstrap "file://$working_dir/copyBack/spack-bootstrap-cache"
+_cmd $DEBUG_1 spack mirror add --scope=site __local_compilers "file://$working_dir/copyBack/spack-compiler-cache"
+_cmd $DEBUG_1 spack mirror add --scope=site __local_sources "file://$working_dir/copyBack/spack-source-cache"
 
 # Make a cut-down mirror configuration for safe concretization.
 if (( concretize_safely )); then

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -914,7 +914,7 @@ if (( failed == 1 )) && [ \"${cache_write_binaries:-none}\" != none ]; then \
       -r --rebuild-index \$(spack find --no-groups); \
   tag_text=ALERT _report $ERROR \"emergency buildcache dump COMPLETE\"; \
 fi; \
-eval exec \"$STDOUT>&-\" \"$STDERR>&-\"\
+exec $STDOUT>&- $STDERR>&-\
 " EXIT
 ####################################
 

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -82,12 +82,13 @@ _cmd() {
 _copy_back_logs() {
   local tar_tmp="$working_dir/copyBack/tmp"
   local spack_env= env_spec= install_prefix=
-  mkdir -p "$tar_tmp/spack_env"
+  mkdir -p "$tar_tmp/"{spack_env,spack-stage}
   cd "$spack_env_top_dir"
   _cmd $DEBUG_1 spack clean -dmp
   _cmd $DEBUG_1 $PIPE tar -c *.log *-out.txt *.yaml etc var/spack/environments \
     | _cmd $DEBUG_1 tar -C "$tar_tmp/spack_env" -x
-  _cmd $DEBUG_1 $PIPE tar -C "$TMPDIR" -c spack-stage | _cmd $DEUBG_1 tar -C "$tar_tmp" -x
+  _cmd $DEBUG_1 $PIPE tar -C "$(spack location -S)" -c . \
+    | _cmd $DEUBG_1 tar -C "$tar_tmp/spack-stage" -x
   for spack_env in $(spack env list); do
     _cmd $DEBUG_1 $PIPE spack -e $spack_env \
           ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -661,7 +661,7 @@ _process_environment() {
                 _cmd $DEBUG_1 $PROGRESS spack \
                      -e $env_name \
                      ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-                     mirror create -aD --skip-unstable-versions "$working_dir/copyBack/spack-source-cache"
+                     mirror create -aD --skip-unstable-versions -d "$working_dir/copyBack/spack-source-cache"
          }
     } \
       && _do_build_and_test \

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -799,7 +799,7 @@ _piecemeal_build() {
     _report $DEBUG_2 "  ${same_level_deps[@]/%/$'\n'              }"
     _cmd $DEBUG_1 $INFO \
          "${spack_install_cmd[@]}" \
-         ${same_level_deps[*]:+--no-add "${same_level_deps[@]//*\///}"} \
+         ${same_level_deps[*]:+"${same_level_deps[@]//*\///}"} \
       || return
     # Add deps to list of installed deps.
     installed_deps+=(${same_level_deps[*]:+"${same_level_deps[@]##*/}"})

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -262,7 +262,7 @@ _piecemeal_build() {
 _process_environment() {
   local env_cfg="$1"
   if [[ "$env_cfg" =~ ^[a-z][a-z0-9_-]*://(.*/)?(.*) ]]; then
-    curl -o "${BASH_REMATCH[2]}" --insecure --fail -L "$env_cfg" \
+    curl -o "${BASH_REMATCH[2]}" -N --no-progress-meter --insecure --fail -L "$env_cfg" \
       || _die $EXIT_PATH_FAILURE "unable to obtain specified environment config file \"$env_cfg\""
     env_cfg="${BASH_REMATCH[2]}"
   fi
@@ -750,7 +750,7 @@ for config_file in ${spack_config_files[*]:+"${spack_config_files[@]}"}; do
   [ "$cf_scope" = "$config_file" ] && cf_scope=site
   config_file="${config_file##*'|'}"
   if [[ "$config_file" =~ ^[a-z][a-z0-9_-]*://(.*/)?(.*) ]]; then
-    curl -o "${BASH_REMATCH[2]}" --insecure --fail -L "$config_file" \
+    curl -o "${BASH_REMATCH[2]}" -N --no-progress-meter --insecure --fail -L "$config_file" \
       || _die $EXIT_PATH_FAILURE "unable to obtain specified config file \"$config_file\""
     config_file="${BASH_REMATCH[2]}"
   fi

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -371,7 +371,8 @@ _classify_concretized_specs() {
   OIFS="$IFS"; IFS=$'\n'; root_hashes=($(echo "${root_hashes[*]}" | sort -u)); IFS="$OIFS"
   _report $DEBUG_2 "root_hashes=\n             ${root_hashes[@]/%/$'\n'  }"
   idx=${#hashes[@]}
-  _report $DEBUG_1 "examined $specline_idx speclines and found $idx hashes and ${#root_hashes[@]} root hashes"
+  local n_unique=$(IFS=$'\n' echo "${hashes[*]}" | sort -u | wc -l)
+  _report $DEBUG_1 "examined $specline_idx speclines and found ${#root_hashes[@]} roots and $n_unique packages"
 }
 
 # Report and execute this command.

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -71,7 +71,8 @@ BRIEF OPTIONS
 
   --cache-write-(bootstrap|sources|binaries[= ](all|none|deps|dependencies|(no|non)[_-]roots|roots)) \
   --no-cache-write-(binaries|bootstrap|sources) --clear-mirrors \
-  --color[= ](auto|always|never) --(debug|verbose)-spack \
+  --color[= ](auto|always|never) \
+  --(debug|verbose)-spack-(bootstrap|buildcache|concretize|install) \
   --(no-)?safe-concretize --spack-python[= ]<python-exec> \
   --spack-config-cmd[= ]<config-cmd-string>+ \
   --spack-config-file[= ](<cache-name>\|)?<config-file>+ \
@@ -112,10 +113,9 @@ HELP AND DIAGNOSTIC OPTIONS
 
     Set the verbosity to the indicated value.
 
-  --debug-spack
-  --verbose-spack
+  --(debug|verbose)-spack-(bootstrap|buildcache|concretize|install)
 
-    Add -d or -v options to invocations of Spack.
+    Add -d or -v options to appropriate invocations of Spack.
 
   --color[= ](auto|always|never)
 

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -91,10 +91,12 @@ _copy_back_logs() {
   for spack_env in $(spack env list); do
     _cmd $DEBUG_1 $PIPE spack -e $spack_env \
           ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
+          --color=never \
           spec --format '{fullname}{/hash}' \
       | while read root_spec; do
       _cmd $DEBUG_1 $PIPE spack \
         ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
+        --color=never \
         find -d --no-groups \
         --format '{fullname}{/hash}'$'\t''{prefix}' \
         "$root_spec"
@@ -146,6 +148,7 @@ _do_build_and_test() {
       $(IFS="$OIFS" \
            spack -e $env_name \
            ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
+          --color=never \
            spec -NL \
           | sed -Ene '/^Concretized$/,/^$/ { /^(Concretized|-+)?$/ b; p;  }')
     )
@@ -321,6 +324,7 @@ _process_environment() {
     && _cmd $DEBUG_1 $PIPE spack \
             -e $env_name \
             ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
+          --color=never \
          spec -j \
       | csplit -f "$env_name" -b "_%03d.json" -z -s - '/^\}$/+1' '{*}' \
     && { ! (( cache_write_sources )) \
@@ -528,6 +532,7 @@ fi
 } 2>/dev/null
 ########################################################################
 
+color=
 concretize_safely=1
 si_root=https://github.com/FNALssi/spack-infrastructure.git
 si_ver=master
@@ -550,6 +555,8 @@ while (( $# )); do
     --cache-write-bootstrap) cache_write_bootstrap=1;;
     --cache-write-sources) cache_write_sources=1;;
     --clear-mirrors) clear_mirrors=1;;
+    --color) color="$2"; shift;;
+    --color=*) color="${1#*=}";;
     --debug-spack-*|--verbose-spack-*) eval "${1//-/_}=1";;
     --help|-h|-\?) usage 2; exit 1;;
     --no-cache-write-binaries) cache_write_binaries=none;;
@@ -589,6 +596,9 @@ while (( $# )); do
   esac
   shift
 done
+
+color_arg=${color:+--color=$color}
+common_spack_opts+=($color_arg)
 
 ####################################
 # Supress all but warnings and errors if we need quiet.

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -400,7 +400,7 @@ _do_build_and_test() {
     done
   else
     # Build the whole environment.
-    _report "building environment $env_name"
+    _report $PROGRESS "building environment $env_name"
     local spack_build_env_cmd=(
       "${spack_install_cmd[@]}"
       ${extra_cmd_opts[*]:+"${extra_cmd_opts[@]}"}
@@ -478,7 +478,7 @@ _piecemeal_build() {
       ${extra_cmd_opts[*]:+"${extra_cmd_opts[@]}"} \
       ${build_root_hash:+--no-add "/${build_root_hash##*/}"}
   )
-  _cmd $PROGRESS $INFO "${spack_build_root_cmd[@]}" || return
+  _cmd $DEBUG_1 $INFO "${spack_build_root_cmd[@]}" || return
   installed_deps+=(${build_root_hash:+"$build_root_hash"})
   if (( ${#buildable_dep_hashes[@]} + ${#build_root_hash} )); then
     OIFS="$IFS"; IFS=$'\n'
@@ -946,7 +946,7 @@ mkdir -p "$spack_env_top_dir" \
 cd "$spack_env_top_dir"
 if ! [ -f "$spack_env_top_dir/setup-env.sh" ]; then
   make_spack_cmd=(make_spack --spack_release $spack_ver --minimal $ups_opt "$spack_env_top_dir")
-  _report $INFO "bootstrapping Spack $spack_ver"
+  _report $PROGRESS "bootstrapping Spack $spack_ver"
   PATH="$TMP/bin:$PATH" \
       _cmd $PROGRESS ${make_spack_cmd[*]:+"${make_spack_cmd[@]}"} \
     || _die "unable to install Spack $spack_ver"

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -69,31 +69,31 @@ EOF
   cat <<\EOF
 BRIEF OPTIONS
 
-  --cache-write-(sources|binaries[= ](all|none|deps|dependencies|(no|non)[_-]roots|roots)) \
-  --no-cache-write-(sources|binaries) \
-  --extra-(sources|binaries)-write-cache[= ](<cache-name>\|)?|<cache-path>|<cache-url>)(,...)+ \
-  --clear-mirrors \
-  --color[= ](auto|always|never) \
-  --(debug|verbose)-spack-(bootstrap|buildcache|concretize|install) \
-  --(no-)?fail-fast \
-  --(no-)?safe-concretize \
-  --spack-python[= ]<python-exec> \
-  --spack-config-cmd[= ]<config-cmd-string>+ \
-  --spack-config-file[= ](<cache-name>\|)?<config-file>+ \
-  --spack-infrastructure-root[= ]<repo> \
-  --spack-infrastructure-version[= ]<version> \
-  --spack-repo[= ]<path>|<repo>(\|<version|branch>)? \
-  --spack-root[= ]<repo> \
-  --spack-version[= ]<version> -\
-  -test[= ](all|none|root) \
-  -q \
-  --quiet \
-  [+-]v+ \
-  --verbosity[= ](-?[0-9]+|INFO|WARNING|(FATAL_|INTERNAL_)?ERROR|INFO|PROGRESS|DEBUG_[1-9][0-9]*) \
-  --no-ups \
-  --ups[= ](plain|traditional|unified|-[ptu]) \
-  --with-cache[= ](<cache-name>\|)?|<cache-path>|<cache-url>)(,...)+ \
-  --with-concretiz(e|ing|ation)-cache[= ](<cache-name>\|)?|<cache-path>|<cache-url>)(,...)+ \
+  --cache-write-(sources|binaries[= ](all|none|deps|dependencies|(no|non)[_-]roots|roots))
+  --no-cache-write-(sources|binaries)
+  --extra-(sources|binaries)-write-cache[= ](<cache-name>\|)?|<cache-path>|<cache-url>)(,...)+
+  --clear-mirrors
+  --color[= ](auto|always|never)
+  --(debug|verbose)-spack-(bootstrap|buildcache|concretize|install)
+  --(no-)?fail-fast
+  --(no-)?safe-concretize
+  --spack-python[= ]<python-exec>
+  --spack-config-cmd[= ]<config-cmd-string>+
+  --spack-config-file[= ](<cache-name>\|)?<config-file>+
+  --spack-infrastructure-root[= ]<repo>
+  --spack-infrastructure-version[= ]<version>
+  --spack-repo[= ]<path>|<repo>(\|<version|branch>)?
+  --spack-root[= ]<repo>
+  --spack-version[= ]<version>
+  --test[= ](all|none|root)
+  -q
+  --quiet
+  [+-]v+
+  --verbosity[= ](-?[0-9]+|INFO|WARNING|(FATAL_|INTERNAL_)?ERROR|INFO|PROGRESS|DEBUG_[1-9][0-9]*)
+  --no-ups
+  --ups[= ](plain|traditional|unified|-[ptu])
+  --with-cache[= ](<cache-name>\|)?|<cache-path>|<cache-url>)(,...)+
+  --with-concretiz(e|ing|ation)-cache[= ](<cache-name>\|)?|<cache-path>|<cache-url>)(,...)+
   --working-dir[= ]<dir>
 
   [ Options suffixed with + are repeatable and cumulative ]

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -384,7 +384,7 @@ _classify_concretized_specs() {
   _report $DEBUG_2 "root_hashes=\n             ${root_hashes[@]/%/$'\n'  }"
   idx=${#hashes[@]}
   local n_unique=$(IFS=$'\n'; echo "${hashes[*]}" | sort -u | wc -l)
-  _report $DEBUG_1 "examined $specline_idx speclines and found ${#root_hashes[@]} roots and $n_unique packages"
+  _report $DEBUG_1 "examined $specline_idx speclines and found ${#root_hashes[@]} roots and $n_unique unique packages"
 }
 
 # Report and execute this command.

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -719,7 +719,7 @@ _process_environment() {
       _cmd $DEBUG_1 $PROGRESS \
            spack \
            ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-           buildcache update-index -k -d "$working_dir/copyBack/spack-$binary_mirror-cache"
+           buildcache update-index -k "$working_dir/copyBack/spack-$binary_mirror-cache"
     fi
     unset hashes_to_cache
   fi

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1297,7 +1297,8 @@ _configure_spack
 
 ####################################
 # Safe, comprehensive cleanup.
-trap "[ -d \"$TMP\" ] && rm -rf \"$TMP\" 2>/dev/null; \
+trap "trap - EXIT; \
+[ -d \"$TMP\" ] && rm -rf \"$TMP\" 2>/dev/null; \
 [ -f \"\$mirrors_cfg~\" ] && mv -f \"\$mirrors_cfg\"{~,}; \
 _copy_back_logs; \
 if (( failed )) && (( want_emergency_buildcache )); then \


### PR DESCRIPTION
- Jenkins job script to build one or more Spack environments.
- Fix printf error
- Fix faulty curl option
- Fix faulty curl option (2)
- Key info is on STDERR
- Re-work the emergency BuildCache dump procedure
- Fix regex
- Attempt to resolve more keyid issues
- Work with older Spack
- Guarantee only one match
- Support --spack-config-cmd
- Fix silliness
- More flexible config commands
- More improvements to build-spack-env
- --clear-mirrors should not affect command-line cache-url entries
- Fix source mirror command
- Move up the mirror-clearing operation
- Improve commentary
- Relocate secret handling
- Ensure bootstrap takes place before we (e.g.) mess with install padding
- Add new options for controllability from jobs
- Options for debugging some Spack commands
- Fix thinko.
- Remove vestigial options
- Added install safety
- Separate build caches under copyBack/ for ease of retrieval
- When testing roots only, ensure we actually test them all
- build-spack-env.sh working, with caveats:
- Remove unwanted diagnostic termination
- Refine copyBack contents
- Remove unnecessary `--save-all-tests` option
- Fix test argument handling
- Improve robustness
- Better handling of non-terminal compiler environments
- Improve diagnostic format consistency
- Allow for use of external Python
- Fix typo
- Remove unwanted -e option from spack invocation
- Improve structure and content of log tarball
- Fix silliness
- Fix index logic
- Handle non-standard SPACK_GNUPGHOME
- Overhaul output and diagnostics
- Reset default verbosity to INFO
- Handle "non_roots" as a synonym for "no_roots"
- Fix argument bundling
- Support judicious use of color
- Fix broken command
- Optimize curl output for redirected output
- Improve capture of incomplete build information
- Improve formatting
- Improve in-script color handling
- Improve control of verbosity
- Remove redundant handling of -h
- Add usage documentation
- Man pages lie, apparently
- Correct documentation for some debug options
- Improve debug output
- First pass at handling UPS
- Cache improvements
- Minor diagnostic improvements
- Remove problematic bootstrap caching and update documentation
- Fix cleanup commands and reporting thereof
- Remove unnecessary eval
- Ensure removal of empty directories after removing roots from cache
- Handle clang/llvm dichotomy when adding compiler to Spack
- Add compiler to Spack even if terminal
- Remove explicit bootstrapping of Spack's tools
- Adding of secret key to Spack's keyring should be quieter
- Handle newer versions of make_packages_yaml
- Accommodate pickier URL handling for mirrors
- build-spack-env.sh nominally ready for real work
- Fix repo/branch separator
- Fix buildcache/mirror commands
- Fix source mirror creation
- Fix BuildCache writing
- Add missing documentation
- Extra safety on install
- More deprecated Spack options
- Improve modularity and progress reports
- Fix logic error and improve modularity
- Fix function name copy/paste error
- Improve help text organization
- New cache options
- Fix missing done
- Remove unnecessary eval
- Remove dangerous relative paths from PATH at Spack setup time
- Actually finish implementing `--with-concretizing-cache`.
- Ensure working_dir has its final value before using it
- Help text: one option per line
- spack-infrastructure -> fermi-spack-tools
- Support Spack repo location
- Support --with-padding
- Fix logic error
- Fix logic. Again.
- Give more useful information
- Omit duplicative option
- Properly check a possibly-empty function argument
- Support --query-packages in make_spack
- Handle removed `-r` option to `spack buildcache create`
- TMP definition should be earlier; use two-stage cleanup
- Fix message quoting
- Upload to emergency build cache by hash to avoid duplicate complaints
- New option `--(no-)?emergency-buildcache`
- Prevent trap recursion
- Modify compiler entry to use the binutils it was built with
- Fix typo
- Improve informational message
- More appropriate failure categories
- Improve failure message and category
- Update compiler flags appropriately for LLVM/Clang
