### PR TITLE
enhancing make_subspack: faster, new options for developing packages

### DIFF
--- a/bin/make_subspack
+++ b/bin/make_subspack
@@ -10,16 +10,27 @@ get_from_bootstrap() {
 
 
 usage() {
-    echo "usage: make_subspack [--spack_release ver] [--spack_repo url] [-t|-u] /path/to/existing/spack /path/to/new/area"
+        echo "usage: make_subspack [options] [-t|-u] path/to/existing/spack /path/to/new/area"
+        echo " options are:"
+        echo "--with_padding      enable directory padding in config"
+        echo "--spack_release xx  install spack release xx"
+        echo "--spack_repo url    use spack repo url"
+        echo "--test_env name     make a local version of 'name' called 'name_local'"
+        echo "--test_dev p1:p2... make packages p1, p2, ... development in above"
+        echo "-v                  verbose"
+        echo "-t                  traditional layout"
+        echo "-u                  unified layout (default)"
 }
 
 parse_args() {
-    spack_repo=$(get_from_bootstrap default_spack_repo)
-    spack_release=$(get_from_bootstrap  default_spack_version)
+    test_env=""
+    test_dev=""
+    spack_repo=default
+    spack_release=default
     padding=false
     verbose=false
 
-    eval set : $(getopt --longoptions with_padding,spack_release:,spack_repo --options vtu -- "$@")
+    eval set : $(getopt --longoptions with_padding,spack_release:,spack_repo,test_env:,test_dev: --options vtu -- "$@")
     shift
 
     while echo x$1 | grep x- > /dev/null
@@ -28,6 +39,8 @@ parse_args() {
         x--with_padding)  padding=true; shift ;;
         x--spack_release) spack_release=$2; shift; shift;;
         x--spack_repo)    spack_repo=$2; shift; shift;;
+        x--test_env)      test_env=$2; shift; shift;;
+        x--test_dev)      test_dev=$2; shift; shift;;
         x-t) unified=false; shift ;;
         x-u) unified=true; shift ;;
         x-u) verbose=true; shift ;;
@@ -38,15 +51,7 @@ parse_args() {
 
     if [ $# != 2 ]
     then
-        echo "usage: make_subspack [options] [-t|-u] path/to/existing/spack /path/to/new/area"
-        echo " options are:"
-        echo "--with_padding      enable directory padding in config"
-        echo "--spack_release xx  install spack release xx"
-        echo "--spack_repo url    use spack repo url"
-        echo "-v                  verbose"
-        echo "-t                  traditional layout"
-        echo "-u                  unified layout (default)"
-         
+        usage
         exit 1
     fi
 
@@ -111,6 +116,12 @@ x/*) ;;
 x*)  spackbindir="$PWD/$spackbindir"
 esac
 
+: starting: $*
+
+unset SPACK_ENV
+unset SPACK_ROOT
+export SPACK_DISABLE_LOCAL_CONFIG=true
+
 parse_args "$@"
 
 if $verbose
@@ -162,7 +173,19 @@ case "$spack_root" in
 *github.com*) args="--depth 4" ;;
 *) args="";;
 esac
-git clone $args -b $spack_release $spack_repo $SPACK_ROOTb
+
+# default to just doing a fs-based clone, which saves lots of space and time
+if [ $spack_repo = default ]
+then
+    spack_repo=$src/.git
+fi
+if [ $spack_release = default ]
+then
+    branchbits=""
+else
+    branchbits="-b $spack_release"
+fi
+git clone $args $branchbits $spack_repo $SPACK_ROOTb
 cd $SPACK_ROOT
 
 echo "installing config.yaml..."
@@ -172,6 +195,8 @@ cp $spackbindir/../templates/config.yaml.unified${extra} $SPACK_ROOT/etc/spack/c
 else
 cp $spackbindir/../templates/config.yaml.traditional${extra} $SPACK_ROOT/etc/spack/config.yaml
 fi
+
+os=`$SPACK_ROOT/bin/spack arch --operating-system`
 
 message "installing packages.yaml"
 test -d  $SPACK_ROOT/etc/spack/${os} || mkdir $SPACK_ROOT/etc/spack/${os}
@@ -217,7 +242,6 @@ rollout*|0.1[67]*) ;;
    ;;
 esac
 
-os=`$SPACK_ROOT/bin/spack arch --operating-system`
 
 # copy compilers and packages
 test -d  $SPACK_ROOT/etc/spack/$os ||  mkdir -p  $SPACK_ROOT/etc/spack/$os
@@ -260,5 +284,28 @@ done
 
 # use the upstream's bootstrap area...
 $SPACK_ROOT/bin/spack bootstrap root --scope=site $install_tree_path/.bootstrap
+
+if [ "$test_env" != "" ]
+then
+    message creating ${test_env}_local environment ...
+    $SPACK_ROOT/bin/spack env create ${test_env}_local $src/var/spack/environments/${test_env}/spack.yaml
+fi
+
+if [ "$test_dev" != "" ]
+then
+   if [ $test_env == "" ]
+   then
+       echo "--test_pkg specified without --test-env, ignoring"
+   else
+       localspackyaml=$SPACK_ROOT/var/spack/environments/${test_env}_local/spack.yaml
+       IFS=":$IFS"
+       for pkg in $test_dev
+       do
+           message making $pkg develop in ${test_env}_local environment ...
+           perl -pi -e "s/([ ^]${pkg}@=?)[0-9.]*/\$1develop/g;"  $localspackyaml
+           $SPACK_ROOT/bin/spack --env ${test_env}_local develop $pkg@develop
+       done
+   fi
+fi 
 
 echo "done."


### PR DESCRIPTION
Adding flags for setting up a "test-release" subspack to make_subspack:
--test_env env-name   # specify the base environment for our test environment
--test_dev pkg1:pkg2:... # specify the packages to flag as develop

So your subspack will have a new environment env-name_local, which
is all setup to concretize and install off develop. 

Also made default to clone Spack from the parent spack instance as a local fileystem
clone, which is much faster.