### PR TITLE
Remove problematic `^libc` from `gettext` external spec

### DIFF
--- a/bin/make_packages_yaml
+++ b/bin/make_packages_yaml
@@ -330,14 +330,6 @@ do
   opts=`grep "^$spp[ \t]" $optf | sed -e "s/^$spp[ \t]*//"`
   [ -n "$opts" ] && opts=" $opts"
 
-  #dependencies, one needed so far on gettext
-  if [ "$spp" = "gettext" ]
-  then
-    deps=" ^libc"
-  else
-    deps=""
-  fi
-
   # also find any cvmfs versions
   cvmfsversions=`get_cvmfs_spack_versions $spp`
 

--- a/templates/packages.yaml.scientific7
+++ b/templates/packages.yaml.scientific7
@@ -149,7 +149,7 @@ packages:
     buildable: False
   gettext:
     externals:
-    - spec: "gettext ~bzip2+curses~git+libunistring+libxml2~tar+xz @0.19.8.1 %gcc@4.8.5 os=scientific7 ^libc"
+    - spec: "gettext ~bzip2+curses~git+libunistring+libxml2~tar+xz @0.19.8.1 %gcc@4.8.5 os=scientific7"
       prefix: /usr
     # buildable: False
   git:


### PR DESCRIPTION
The original behavior has been found to cause recent (post 2023-05-18) versions of the Spack concretizer to fail. According to Massimiliano Culpo, specifying a dependency on an external spec has no meaning, and was—at best—`NOP` in earlier versions of the concretizer.