### PR TITLE
Check if package installed from buildcache  before creating buildcache

### DIFF
--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -718,7 +718,7 @@ _maybe_cache_binaries() {
                  ${extra_sources_write_cache[*]:+"${extra_sources_write_cache[@]}"}; do
       _report $PROGRESS "caching$msg_extra binary packages for environment $env_name to $cache"
       for hash in "${hashes_to_cache[@]}";do
-        if [ ! -f $(spack location -i $hash)/.spack/binary_distribution ]; then
+        if [ ! -f "$(spack location -i $hash)/.spack/binary_distribution" ]; then
           _cmd $DEBUG_1 $PROGRESS \
            spack \
            ${__debug_spack_buildcache:+-d} \
@@ -1340,7 +1340,7 @@ _copy_back_logs; \
 if (( failed )) && (( want_emergency_buildcache )); then \
   tag_text=ALERT _report $ERROR \"emergency buildcache dump...\"; \
   for spec in \$(spack find -L | sed -Ene 's&^([[:alnum:]]+).*\$&/\\1&p');do \
-    if [ ! -f \$(spack location -i \$spec)/.spack/binary_distribution ]; then
+    if [ ! -f \"\$(spack location -i \$spec)/.spack/binary_distribution\" ]; then
       _cmd $ERROR $PIPE spack \
       \${common_spack_opts[*]:+\"\${common_spack_opts[@]}\"} \
       buildcache create --deptype=all --only=package \

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -561,7 +561,7 @@ _copy_back_logs() {
   mkdir -p "$tar_tmp/"{spack_env,spack-stage}
   cd "$spack_env_top_dir"
   _cmd $DEBUG_3 spack clean -dmp
-  _cmd $DEBUG_3 $PIPE tar -c $spack_source_dir/*.log $spack_source_dir/*-out.txt $spack_source_dir/*.yaml $spack_source_dir/etc $spack_source_dir/spack/environments \
+  _cmd $DEBUG_3 $PIPE tar -c $spack_source_dir/*.log $spack_source_dir/*-out.txt $spack_source_dir/*.yaml $spack_source_dir/etc $spack_source_dir/var/spack/environments \
     | _cmd $DEBUG_3 tar -C "$tar_tmp/spack_env" -x
   _cmd $DEBUG_3 $PIPE tar -C "$(spack location -S)" -c . \
     | _cmd $DEBUG_3 tar -C "$tar_tmp/spack-stage" -x

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -718,7 +718,9 @@ _maybe_cache_binaries() {
                  ${extra_sources_write_cache[*]:+"${extra_sources_write_cache[@]}"}; do
       _report $PROGRESS "caching$msg_extra binary packages for environment $env_name to $cache"
       for hash in "${hashes_to_cache[@]}";do
-        if [ ! -f "$(spack location -i $hash)/.spack/binary_distribution" ]; then
+        if [  -f "$(spack location -i $hash)/.spack/binary_distribution" ]; then
+	  _report $DEBUG_1 "Skipping package installed from buildcache $hash"
+	else
           _cmd $DEBUG_1 $PROGRESS \
            spack \
            ${__debug_spack_buildcache:+-d} \
@@ -1340,7 +1342,9 @@ _copy_back_logs; \
 if (( failed )) && (( want_emergency_buildcache )); then \
   tag_text=ALERT _report $ERROR \"emergency buildcache dump...\"; \
   for spec in \$(spack find -L | sed -Ene 's&^([[:alnum:]]+).*\$&/\\1&p');do \
-    if [ ! -f \"\$(spack location -i \$spec)/.spack/binary_distribution\" ]; then
+    if [  -f \"\$(spack location -i \$spec)/.spack/binary_distribution\" ]; then
+      _report $ERROR skipping package installed from buildcache \$spec;\
+      else \
       _cmd $ERROR $PIPE spack \
       \${common_spack_opts[*]:+\"\${common_spack_opts[@]}\"} \
       buildcache create --deptype=all \

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1343,7 +1343,7 @@ if (( failed )) && (( want_emergency_buildcache )); then \
     if [ ! -f \"\$(spack location -i \$spec)/.spack/binary_distribution\" ]; then
       _cmd $ERROR $PIPE spack \
       \${common_spack_opts[*]:+\"\${common_spack_opts[@]}\"} \
-      buildcache create --deptype=all --only=package \
+      buildcache create --deptype=all \
       \${buildcache_key_opts[*]:+\"\${buildcache_key_opts[@]}\"} \
       \$buildcache_rel_arg --rebuild-index \
       \"$working_dir/copyBack/spack-emergency-cache\" \


### PR DESCRIPTION
This speeds up the creation of environment buildcaches by checking if the package was installed from buildcache and skipping if it was.