### PR TITLE
Update from v0.21-fermi

### DIFF
--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -726,7 +726,7 @@ _maybe_cache_binaries() {
            ${__debug_spack_buildcache:+-d} \
            ${__verbose_spack_buildcache:+-v} \
            ${common_spack_opts[*]:+"${common_spack_opts[@]}"} \
-           buildcache create --deptype=all \
+           buildcache create \
            ${buildcache_package_opts[*]:+"${buildcache_package_opts[@]}"} \
            ${buildcache_key_opts[*]:+"${buildcache_key_opts[@]}"} \
            ${buildcache_rel_arg} "$cache" \
@@ -1347,7 +1347,7 @@ if (( failed )) && (( want_emergency_buildcache )); then \
       else \
       _cmd $ERROR $PIPE spack \
       \${common_spack_opts[*]:+\"\${common_spack_opts[@]}\"} \
-      buildcache create --deptype=all \
+      buildcache create \
       \${buildcache_key_opts[*]:+\"\${buildcache_key_opts[@]}\"} \
       \$buildcache_rel_arg --rebuild-index \
       \"$working_dir/copyBack/spack-emergency-cache\" \

--- a/bin/make_spack
+++ b/bin/make_spack
@@ -20,7 +20,7 @@ install_latest() {
         hash_pkg_ver=`spack -k buildcache list --long --allarch "$pkg $plat" | tail -1`
         echo "make_spack: info: latest $pkg is $hash_pkg_ver"
         hash=`echo $hash_pkg_ver | sed -e 's/ .*//'`
-        spack -k buildcache install -o -a -m "/$hash"
+        spack -k buildcache install -o -m "/$hash"
     else
         spack -k install "$pkg $plat"
     fi
@@ -146,12 +146,17 @@ create_spack() {
                ;;
             esac
             export plat="target=`uname -i` os=`spack arch --operating-system`"
-            spack mirror add --scope site fnal $binary_cache
-            spack buildcache update-index -k fnal
-            spack mirror add --scope site scisoft $binary_cache_bak
-            spack buildcache update-index -k scisoft
-            spack -k buildcache keys --install --trust --force
-            add_recipe_repos
+            if $minimal
+            then
+              :
+            else
+              spack mirror add --scope site fnal $binary_cache
+              spack buildcache update-index -k fnal
+              spack mirror add --scope site scisoft $binary_cache_bak
+              spack buildcache update-index -k scisoft
+              spack -k buildcache keys --install --trust --force
+            fi
+	    add_recipe_repos
             if $upgrading
             then
                 spack reindex

--- a/templates/packages.yaml.almalinux9
+++ b/templates/packages.yaml.almalinux9
@@ -136,11 +136,6 @@ packages:
     - spec: "gdbm @1.19 %gcc@11.3.1 os=almalinux9"
       prefix: /usr
     buildable: False
-  glib:
-    externals:
-    - spec: "glib @2.68.4 %gcc@11.3.1 os=almalinux9"
-      prefix: /usr
-    buildable: False
   gettext:
     externals:
     - spec: "gettext ~bzip2+curses~git+libunistring+libxml2~tar+xz @0.21 %gcc@11.3.1 os=almalinux9"

--- a/templates/packages.yaml.scientific7
+++ b/templates/packages.yaml.scientific7
@@ -156,11 +156,6 @@ packages:
     externals:
     - spec: "git @1.8.3.1 %gcc@4.8.5 os=scientific7"
       prefix: /usr
-  glib:
-    externals:
-    - spec: "glib @2.56.1 %gcc@4.8.5 os=scientific7"
-      prefix: /usr
-    buildable: False
   gmake:
     externals:
     - spec: "gmake @3.82 %gcc@4.8.5 os=scientific7"


### PR DESCRIPTION
- Remove --deptype=all
- Remove obsolete update-index and keys commands
- Skip adding mirrors and keys in minimal install
- Don't use system glib
- Remove glib on slf7
