### PR TITLE
Minor improvements to build-spack-env.sh

### DIFF
--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -1394,13 +1394,17 @@ environment_specs=("$@")
 num_environments=${#environment_specs[@]}
 env_idx=0
 
-####################################
-# Build each specified environment.
-for env_cfg in ${environment_specs[*]:+"${environment_specs[@]}"}; do
-  _report $PROGRESS "processing user-specified environment configuration $env_cfg"
-  _process_environment "$env_cfg"
-done
-####################################
+if (( ! num_environments )); then # NOP
+  _report $INFO "no environment configurations specified: exiting after setup"
+else
+  ####################################
+  # Build each specified environment.
+  for env_cfg in ${environment_specs[*]:+"${environment_specs[@]}"}; do
+    _report $PROGRESS "processing user-specified environment configuration $env_cfg"
+    _process_environment "$env_cfg"
+  done
+  ####################################
+fi
 
 ### Local Variables:
 ### mode: sh

--- a/bin/build-spack-env.sh
+++ b/bin/build-spack-env.sh
@@ -62,7 +62,7 @@ working_dir="${WORKSPACE:=$(pwd)}"
 usage() {
   cat <<EOF
 
-usage: $prog <options> (--)? (<spack-env-yaml-file>|<spack-env-yaml-url>)+
+usage: $prog <options> (--)? [(<spack-env-yaml-file>|<spack-env-yaml-url>)] ...
        $prog (-[h?]|--help)
 
 EOF


### PR DESCRIPTION
- Documentation clarity
- Improve trap handling to allow for interruption during copy back
- Report when no environments specified
