### PR TITLE
Make elfutils a system package

### DIFF
--- a/bin/make_packages_yaml
+++ b/bin/make_packages_yaml
@@ -73,7 +73,7 @@ fi
 dst=$1/etc/spack/${sd}${os}/packages.yaml
 
 # packages to make not buildable
-force_system='^(bdftopcf|damageproto|diffutils|expat|findutils|font-util|gdbm|gettext|libc|libfontenc|libice|libx11|libxau|libxcb|libxdamage|libxdmcp|libxext|libxfixes|libxfont|libxkbcommon|libxmu|libxpm|libxrandr|libxrender|libxshmfence|libxt|libxv|libxvmc|libxxf86vm|mesa-glu|mkfontdir|mkfontscale|motif|openssl|pkg-config|pkgconf|tar|tcl|tk|xcb-util-(image|keysyms|renderutil|wm)|xextproto|xorg-server|xproto|xproxymanagementprotocol|xrandr|xtrans|zlib)$'
+force_system='^(bdftopcf|damageproto|diffutils|elfutils|expat|findutils|font-util|gdbm|gettext|libc|libfontenc|libice|libx11|libxau|libxcb|libxdamage|libxdmcp|libxext|libxfixes|libxfont|libxkbcommon|libxmu|libxpm|libxrandr|libxrender|libxshmfence|libxt|libxv|libxvmc|libxxf86vm|mesa-glu|mkfontdir|mkfontscale|motif|openssl|pkg-config|pkgconf|tar|tcl|tk|xcb-util-(image|keysyms|renderutil|wm)|xextproto|xorg-server|xproto|xproxymanagementprotocol|xrandr|xtrans|zlib)$'
 
 # packages to force target (instead of merely preferred)
 force_x86_64='^(hwloc|libpciaccess|libsigsegv)$'

--- a/templates/packagelist
+++ b/templates/packagelist
@@ -28,6 +28,7 @@ coreutils:coreutils:$0
 libcurl:curl:$0-devel
 xorg-x11-proto-devel:damageproto:$0
 diffutils:diffutils:$0
+elfutils:elfutils:$0-devel
 expat:expat:$0-devel
 findutils:findutils:$0
 flex:flex:$0
@@ -89,7 +90,6 @@ ncurses:ncurses:$0-devel
 openssh-clients:openssh:$0
 (openssl[0-9a-z]*)-libs:openssl:\1-devel
 patchelf:patchelf:$0
-perl:perl:$0-devel
 (pkgconfig|pkgconf-pkg-config):pkg-config:$0
 pkgconf:pkgconf:$0
 python[0-9]*:python:$0-devel


### PR DESCRIPTION
`elfutils` does not build cleanly in AL9.5, but the system version is identical to the version that Spack tries to install. (It is required as a dependency of the `qt` stack.)