### PR TITLE
repositories moved to FNALssi/fnal-fife orgs

### DIFF
--- a/bin/make_spack
+++ b/bin/make_spack
@@ -69,17 +69,17 @@ clone_repos() {
       fi
     done <<EOF
         $dir                                            $spack_release  $spack_repo
-        $dir/etc/spack/linux                            main            https://github.com/marcmengel/fermi-etc-spack-linux.git
-        $dir/var/spack/extensions/spack-freeze          main            https://github.com/marcmengel/spack-freeze.git
-        $dir/var/spack/extensions/spack-installdir      main            https://github.com/marcmengel/spack-installdir.git
-        $dir/var/spack/extensions/spack-intersection    main            https://github.com/marcmengel/spack-intersection.git
-        $dir/var/spack/extensions/spack-linuxexternals  main            https://github.com/marcmengel/spack-linuxexternals.git
-        $dir/var/spack/extensions/spack-localbuildcache main            https://github.com/marcmengel/spack-localbuildcache.git
-        $dir/var/spack/extensions/spack-subspack        main            https://github.com/marcmengel/spack-subspack.git
+        $dir/etc/spack/linux                            main            https://github.com/FNALssi/fermi-etc-spack-linux.git
+        $dir/var/spack/extensions/spack-freeze          main            https://github.com/FNALssi/spack-freeze.git
+        $dir/var/spack/extensions/spack-installdir      main            https://github.com/FNALssi/spack-installdir.git
+        $dir/var/spack/extensions/spack-intersection    main            https://github.com/FNALssi/spack-intersection.git
+        $dir/var/spack/extensions/spack-linuxexternals  main            https://github.com/FNALssi/spack-linuxexternals.git
+        $dir/var/spack/extensions/spack-localbuildcache main            https://github.com/FNALssi/spack-localbuildcache.git
+        $dir/var/spack/extensions/spack-subspack        main            https://github.com/FNALssi/spack-subspack.git
         $dir/var/spack/extensions/spack-mpd             main            https://github.com/FNALssi/spack-mpd.git
-        $dir/var/spack/extensions/spack-subspack        main            https://github.com/marcmengel/spack-subspack.git
+        $dir/var/spack/extensions/spack-subspack        main            https://github.com/FNALssi/spack-subspack.git
         $dir/var/spack/repos/fnal_art                   develop         https://github.com/FNALssi/fnal_art.git
-        $dir/var/spack/repos/scd_recipes                master          https://github.com/marcmengel/scd_recipes.git
+        $dir/var/spack/repos/scd_recipes                master          https://github.com/fnal-fife/scd_recipes.git
         $dir/var/spack/repos/nusofthep-spack-recipes    main            https://github.com/NuSoftHEP/nusofthep-spack-recipes.git
         $dir/var/spack/repos/larsoft-spack-recipes      main            https://github.com/LArSoft/larsoft-spack-recipes.git
         $dir/var/spack/repos/artdaq-spack               develop         https://github.com/art-daq/artdaq-spack.git


### PR DESCRIPTION

Having moved the recipe repositories out of my home account on GitHub, we should update the script to
reflect their new homes.