### PR TITLE
Allow deprecated python when installing fermi-spack-tools 

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -148,7 +148,7 @@ main() {
 
     message "installing fermi-spack-tools..."
     pyspec=$(spack config get packages | grep python | grep spec: | sed -e 's/ - spec://') 
-    spack install fermi-spack-tools ^$pyspec
+    spack install --deprecated --reuse fermi-spack-tools ^$pyspec
 
     check_bootstrap
  


### PR DESCRIPTION
In newer Spack releases, the system python is deprecated, so use --deprecated when installing fermi-spack-tools
against the system python. 