### PR TITLE
don't do 'spack install fermi-spack-tools ^system-python' cause we do…

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -111,7 +111,7 @@ message() {
 }
 
 check_bootstrap() {
-    if [ `spack find | egrep 'fermi-spack-tools' | wc -l` = 1 ]
+    if SPACK_USER_CACHE_PATH=/tmp/$USER spack bootstrap status
     then
         :
     else
@@ -145,10 +145,6 @@ main() {
     message "Finding compilers"
 
     spack compiler find --scope=spack
-
-    message "installing fermi-spack-tools..."
-    pyspec=$(spack config get packages | grep python | grep spec: | sed -e 's/ - spec://') 
-    spack install fermi-spack-tools ^$pyspec
 
     check_bootstrap
  


### PR DESCRIPTION
Don't do `spack install fermi-spack-tools ^system-python` cause we don't define system python in packages.yaml by default anymore.
Then just do a spack bootstrap status to check the install.