### PR TITLE
add SPACK_USER_CACHE_PATH to setup-env files

### DIFF
--- a/bin/make_spack
+++ b/bin/make_spack
@@ -150,9 +150,10 @@ add_fermi_setups() {
    do
       echo setenv $var $val >> $dir/share/spack/setup-env.csh
       echo export $var=$val >> $dir/share/spack/setup-env.sh
-   done <<EOF
+   done <<'EOF'
       SPACK_SKIP_MODULES                true
       SPACK_DISABLE_LOCAL_CONFIG        true
+      SPACK_USER_CACHE_PATH /${TMPDIR:-/tmp}/$USER
 EOF
     # source the setup...
     source $dir/share/spack/setup-env.sh


### PR DESCRIPTION
Various Spack operations now try to lockf() on $HOME/.spack/package-repository.lock, which does NOT work
on our NAS home areas currently, but gives I/O errors.

So changing make_spack to add setting SPACK_USER_CACHE_PATH so that that repository lock file ends up in /tmp.

