### PR TITLE
fix typo in phlex repo path

### DIFF
--- a/templates/etc_spack/site/repos.yaml
+++ b/templates/etc_spack/site/repos.yaml
@@ -29,7 +29,7 @@ repos:
     branch: develop
   phlex:
     git: https://github.com/Framework-R-D/phlex-spack-recipes.git
-    destination: $spack/var/spack/phlex-spack-recipes
+    destination: $spack/var/spack/repos/phlex-spack-recipes
     branch: main
   artdaq_spack:
     git: https://github.com/art-daq/artdaq-spack.git


### PR DESCRIPTION
my original PR to add the phlex spack repo had a typo in the path, so the repo ends up in the wrong directory. everything still works fine, but the repo ends up in a different location to the others. this is a minor PR to fix the path in all future spack instances.