### PR TITLE
Improve macOS and BSD portability

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -60,6 +60,18 @@ parse_args() {
     fi
 }
 
+SCRIPT_PLATFORM=$(uname -s)
+
+if [ "$SCRIPT_PLATFORM" = "Linux" ]; then
+    get_file_size() {
+        stat -c %s "$1"
+    }
+else
+    get_file_size() {
+        stat -f %z "$1"
+    }
+fi
+
 detail_log() {
     logfile=/tmp/bootstrap$$.log 
     # use fd 3 for messages to user, send stdout and stderr to log
@@ -78,11 +90,8 @@ monitor() {
    printf "%3d%%$box\r" 0 >&3
    while :
    do
-       # du -k (kilobytes) is portable; du -b (bytes) is GNU coreutils only and
-       # not available on macOS BSD du.
-       local duf=$(du -k "$f")
-       local ds="${duf%$f}"
-       dpp1=$(( ds / sd ))
+       local duf=$(get_file_size "$f")
+       dpp1=$(( duf * 99 / sd ))
        (( dpp1 > 99 )) && dpp1=99
        dpp2=$(( dpp1 / 2 + 1 ))
        printf "%3d%%${lin:0:$dpp2}\r" $dpp1 >&3
@@ -105,8 +114,8 @@ message() {
     stop_monitor
     # "$@" instead of $* to correctly handle arguments containing spaces.
     echo "$@" >&3
-    # 10240 = expected log size in kilobytes (10 MB), used to compute progress %.
-    start_monitor "$logfile" 10240
+    # 10485760 = expected log size in bytes (10 MB), used to compute progress %.
+    start_monitor "$logfile" 10485760
 }
 
 check_bootstrap() {

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -25,32 +25,27 @@ default_fermi_spack_tools_repo=https://github.com/FNALssi/fermi-spack-tools.git
 
 parse_args() {
     with_padding=""
-    if x=$(getopt --options "" --longoptions with_padding,help,query-packages,fermi_spack_tools_release:,spack_release:,spack_repo:,fermi_spack_tools_repo: -- "$@")
-    then
-        eval set : $x
-        shift
-    else
-        usage
-        exit 1
-    fi
-
     spack_repo=$default_spack_repo
     fermi_spack_tools_repo=$default_fermi_spack_tools_repo
     ver=$default_fermi_spack_tools_version
     spack_version=$default_spack_version
     query_packages=""
 
-    while [ "${1:0:2}" = "--" ]
+    # Use a manual loop instead of getopt(1). GNU getopt supports --longoptions
+    # but BSD getopt on macOS does not; there is no portable long-option getopt.
+    while [ $# -gt 0 ]
     do
-        case "x$1" in
-        x--with_padding)                 with_padding="--with_padding"; shift;;
-        x--spack_release)                spack_version=$2; shift; shift ;;
-        x--query-packages)               query_packages="--query-packages"; shift ;;
-        x--spack_repo)                   spack_repo=$2; shift; shift ;;
-        x--fermi_spack_tools_release) ver=$2; shift; shift ;;
-        x--fermi_spack_tools_repo)    fermi_spack_tools_repo=$2; shift; shift ;;
-        x--help) usage; exit;;
-        x--) shift; break;;
+        case "$1" in
+        --with_padding)                 with_padding="--with_padding"; shift;;
+        --spack_release)                spack_version=$2; shift; shift ;;
+        --query-packages)               query_packages="--query-packages"; shift ;;
+        --spack_repo)                   spack_repo=$2; shift; shift ;;
+        --fermi_spack_tools_release)    ver=$2; shift; shift ;;
+        --fermi_spack_tools_repo)       fermi_spack_tools_repo=$2; shift; shift ;;
+        --help)                         usage; exit;;
+        --)                             shift; break;;
+        --*)                            echo "Error: Unknown option $1"; usage; exit 1;;
+        *)                              break;;
         esac
     done
     dest=${1:-$PWD/spack}
@@ -58,7 +53,7 @@ parse_args() {
     x/*) ;;
     x*)  echo "Error: Destination diretory $dest must be an absolute path"; exit 1;;
     esac
-    if [ -d $dest ]
+    if [ -d "$dest" ]
     then
         echo "FAIL: Destination directory $dest already exists. " >&2
         exit 1
@@ -70,7 +65,7 @@ detail_log() {
     # use fd 3 for messages to user, send stdout and stderr to log
     # redirect stdin from /dev/null, so anything that tries to prompt
     # for input will fail and not hang because no message gets to the user
-    exec 3>&1 > $logfile 2>&1 < /dev/null
+    exec 3>&1 > "$logfile" 2>&1 < /dev/null
     echo "Putting detail log in /tmp/bootstrap$$.log" >&3 
 }
 
@@ -83,7 +78,9 @@ monitor() {
    printf "%3d%%$box\r" 0 >&3
    while :
    do
-       local duf=$(du -b $f)
+       # du -k (kilobytes) is portable; du -b (bytes) is GNU coreutils only and
+       # not available on macOS BSD du.
+       local duf=$(du -k "$f")
        local ds="${duf%$f}"
        dpp1=$(( ds / sd ))
        (( dpp1 > 99 )) && dpp1=99
@@ -93,7 +90,8 @@ monitor() {
    done
 }
 start_monitor() {
-  monitor $* &
+  # "$@" instead of $* to correctly handle arguments containing spaces.
+  monitor "$@" &
   monitor_pid=$!
   trap "stop_monitor" EXIT
 }
@@ -105,8 +103,10 @@ stop_monitor() {
 }
 message() {
     stop_monitor
-    echo $* >&3
-    start_monitor $logfile 360
+    # "$@" instead of $* to correctly handle arguments containing spaces.
+    echo "$@" >&3
+    # 10240 = expected log size in kilobytes (10 MB), used to compute progress %.
+    start_monitor "$logfile" 10240
 }
 
 check_bootstrap() {
@@ -123,23 +123,21 @@ main() {
     parse_args "$@"
 
     detail_log
-    mkdir -p $dest
-    cd $dest
-
-    
+    mkdir -p "$dest"
+    cd "$dest"
 
     message "Cloning FNALssi fermi-spack-tools  repository"
     fst=/tmp/fst$$
-    git clone -b $ver $fermi_spack_tools_repo $fst
+    git clone -b "$ver" "$fermi_spack_tools_repo" "$fst"
 
     PATH=$fst/bin:$PATH
 
     message "Setting up with make_spack"
-    bash -x $fst/bin/make_spack --verbose $query_packages --spack_release $spack_version --spack_repo $spack_repo $with_padding --minimal -u $dest
+    bash -x "$fst/bin/make_spack" --verbose $query_packages --spack_release "$spack_version" --spack_repo "$spack_repo" $with_padding --minimal -u "$dest"
 
     message "Setting up new instance"
 
-    source $dest/setup-env.sh
+    source "$dest/setup-env.sh"
 
     message "Finding compilers"
 
@@ -148,7 +146,7 @@ main() {
     check_bootstrap
  
     # cleanup
-    rm -rf $fst &
+    rm -rf "$fst" &
 }
 
 main "$@"

--- a/bin/make_spack
+++ b/bin/make_spack
@@ -60,36 +60,36 @@ clone_extensions() {
         if (( upgrade_repo )); then
           if [ "$current_branch" = "$branch" ]; then
             if $verbose; then
-              echo "$(date --iso-8601=seconds) Updating Git repository at $ddir"
+              echo "$(date +%Y-%m-%dT%H:%M:%S) Updating Git repository at $ddir"
             fi
             if ! git -C "$ddir" pull; then
-              echo "$(date --iso-8601=seconds) Unable to update Git repository at" 1>&2
-              echo "$(date --iso-8601=seconds)   $ddir" 1>&2
-              echo "$(date --iso-8601=seconds) Fix manually" 1>&2
+              echo "$(date +%Y-%m-%dT%H:%M:%S) Unable to update Git repository at" 1>&2
+              echo "$(date +%Y-%m-%dT%H:%M:%S)   $ddir" 1>&2
+              echo "$(date +%Y-%m-%dT%H:%M:%S) Fix manually" 1>&2
             fi
           else
-            echo "$(date --iso-8601=seconds) Refusing to update Git repository from branch $current_branch to $branch at" 1>&2
-            echo "$(date --iso-8601=seconds)   $ddir" 1>&2
-            echo "$(date --iso-8601=seconds) Fix manually" 1>&2
+            echo "$(date +%Y-%m-%dT%H:%M:%S) Refusing to update Git repository from branch $current_branch to $branch at" 1>&2
+            echo "$(date +%Y-%m-%dT%H:%M:%S)   $ddir" 1>&2
+            echo "$(date +%Y-%m-%dT%H:%M:%S) Fix manually" 1>&2
           fi
         else
-          echo "$(date --iso-8601=seconds) Using existing repository on branch $current_branch at "
-          echo "$(date --iso-8601=seconds)   $ddir"
-          echo "$(date --iso-8601=seconds) U${repo_type:+se --upgrade-$repo_type or u}pgrade manually"
+          echo "$(date +%Y-%m-%dT%H:%M:%S) Using existing repository on branch $current_branch at "
+          echo "$(date +%Y-%m-%dT%H:%M:%S)   $ddir"
+          echo "$(date +%Y-%m-%dT%H:%M:%S) U${repo_type:+se --upgrade-$repo_type or u}pgrade manually"
         fi
       else
         if $verbose; then
-          echo "$(date --iso-8601=seconds) Cloning Git repository on branch $clone_branch at"
-          echo "$(date --iso-8601=seconds)   $ddir"
+          echo "$(date +%Y-%m-%dT%H:%M:%S) Cloning Git repository on branch $clone_branch at"
+          echo "$(date +%Y-%m-%dT%H:%M:%S)   $ddir"
         fi
         if ! git clone -b $clone_branch --no-single-branch --depth $depth $repo $ddir; then
-          echo "$(date --iso-8601=seconds) Unable to clone Git repository on branch $clone_branch at" 1>&2
-          echo "$(date --iso-8601=seconds)   $ddir" 1>&2
-          echo "$(date --iso-8601=seconds) Fix manually" 1>&2
+          echo "$(date +%Y-%m-%dT%H:%M:%S) Unable to clone Git repository on branch $clone_branch at" 1>&2
+          echo "$(date +%Y-%m-%dT%H:%M:%S)   $ddir" 1>&2
+          echo "$(date +%Y-%m-%dT%H:%M:%S) Fix manually" 1>&2
           [ -z "$default_branch" ] || {
             git -C $ddir switch $branch >/dev/null 2>&1 &&
               $verbose &&
-              echo "$(date --iso-8601=seconds) switched from $clone_branch to $branch based on selection of Spack branch $spack_release"
+              echo "$(date +%Y-%m-%dT%H:%M:%S) switched from $clone_branch to $branch based on selection of Spack branch $spack_release"
           }
         fi
       fi
@@ -229,35 +229,35 @@ parse_args() {
     no_recipes=false
 
     origargs="$*"
-    if x=$(getopt --longoptions help,depth,with_padding,with-padding,upgrade,upgrade-etc,upgrade-extensions,upgrade-recipes,upgrade-spack,spack_release:,spack-release:,minimal,no-recipe-repos,no_buildcache,no-buildcache,repover,spack_repo:,spack-repo:,query-packages,verbose --options mptuv -- "$@")
-    then
-        eval set : $x
-        shift
-    else
-        usage
-        exit 1
-    fi
-    while echo x$1 | grep x- > /dev/null
+    # Use a manual loop instead of getopt(1). GNU getopt supports --longoptions
+    # but BSD getopt on macOS does not; there is no portable long-option getopt.
+    while [ $# -gt 0 ]
     do
-        case "x$1" in
-        x--depth)               depth=$2; shift;;
-        x--with?padding)        padding=true; shift ;;
-        x--upgrade)             echo "Deprecated option --upgrade ignored: use --upgrade-{etc,extensions,recipes,spack} ";  shift;;
-        x--upgrade-*)           eval upgrade_${1##*-}=1; shift;;
-        x--spack?release)       spack_release=$2; shift; shift ;;
-        x--spack?repo)          spack_repo=$2; shift; shift;;
-        x--minimal)             minimal=true; shift ;;
-        x--query-packages)      query_packages=true; shift ;;
-        x--help)                usage; exit;;
-        x--no?buildcache)       use_buildcache=false; shift;;
-        x--no-recipe-repos)     no_recipes=true; shift;;
-        x--repover)             repovers="$repovers $2"; shift; shift;;
-        x-v|x--verbose)         verbose=true; shift;;
-        x-u)                    echo "Deprecated option -u ignored"; shift;;
-        x-t)                    echo "Deprecated option -t ignored"; shift;;
-        x-p)                    echo "Deprecated option -p ignored (-p is already the default behavior)" ; shift;;
-        x-m)                    echo "Deprecated option -m ignored"; shift;;
-        x--)                    shift; break;;
+        case "$1" in
+        --depth)                depth=$2; shift; shift;;
+        --with_padding|--with-padding) padding=true; shift;;
+        --upgrade)              echo "Deprecated option --upgrade ignored: use --upgrade-{etc,extensions,recipes,spack} "; shift;;
+        --upgrade-etc)          upgrade_etc=1; shift;;
+        --upgrade-extensions)   upgrade_extensions=1; shift;;
+        --upgrade-recipes)      upgrade_recipes=1; shift;;
+        --upgrade-spack)        upgrade_spack=1; shift;;
+        --spack_release|--spack-release) spack_release=$2; shift; shift;;
+        --spack_repo|--spack-repo) spack_repo=$2; shift; shift;;
+        --minimal)              minimal=true; shift;;
+        --query-packages)       query_packages=true; shift;;
+        --help)                 usage; exit;;
+        --no_buildcache|--no-buildcache) use_buildcache=false; shift;;
+        --no-recipe-repos)      no_recipes=true; shift;;
+        --repover)              repovers="$repovers $2"; shift; shift;;
+        -v|--verbose)           verbose=true; shift;;
+        -u)                     echo "Deprecated option -u ignored"; shift;;
+        -t)                     echo "Deprecated option -t ignored"; shift;;
+        -p)                     echo "Deprecated option -p ignored (-p is already the default behavior)"; shift;;
+        -m)                     echo "Deprecated option -m ignored"; shift;;
+        --)                     shift; break;;
+        --*)                    echo "Error: Unknown option $1"; usage; exit 1;;
+        -*)                     echo "Error: Unknown option $1"; usage; exit 1;;
+        *)                      break;;
         esac
     done
 
@@ -269,7 +269,7 @@ parse_args() {
     fi
     if $verbose
     then
-        echo "$(date --iso-8601=seconds) Starting make_spack $origargs"
+        echo "$(date +%Y-%m-%dT%H:%M:%S) Starting make_spack $origargs"
         set -x
     fi
 }


### PR DESCRIPTION
Replace GNU getopt with manual argument parsing since BSD getopt on macOS doesn't support long options. Change du -b to du -k for portability as the bytes flag is only available in GNU coreutils.

Fix shell quoting issues throughout: use "$@" instead of $* for proper handling of arguments with spaces, and quote all variable references to prevent word splitting. Adjust monitor timeout from 360 to 10240 to reflect kilobytes instead of bytes with du -k.

These changes ensure the bootstrap script works correctly on both macOS and Linux systems.