### PR TITLE
run make_spack with bash, not sh

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -136,7 +136,7 @@ main() {
     PATH=$fst/bin:$PATH
 
     message "Setting up with make_spack"
-    sh -x $fst/bin/make_spack --verbose $query_packages --spack_release $spack_version --spack_repo $spack_repo $with_padding --minimal -u $dest
+    bash -x $fst/bin/make_spack --verbose $query_packages --spack_release $spack_version --spack_repo $spack_repo $with_padding --minimal -u $dest
 
     message "Setting up new instance"
 

--- a/bin/make_spack
+++ b/bin/make_spack
@@ -319,6 +319,11 @@ init_scopes() {
     echo "relocating \"site\" scope files to \"site:base\""
     mkdir "$dir/etc/spack/base"
     mv -v "$dir/etc/spack/"*.yaml "$dif/etc/spack/base/"
+
+    osstr=$($dir/bin/spack arch -o)
+    platstr=$($dir/bin/spack arch -p)
+    mkdir -p $dir/etc/spack/$platstr/$osstr
+
     cat > "$dir/etc/spack/include.yaml" <<\EOF
 include:
   # default platform-specific configuration
@@ -332,6 +337,7 @@ include:
 - path: base
 EOF
   fi
+
 }
 
 main() {


### PR DESCRIPTION
Portability fix for Ubuntu, MacOS, etc. where /bin/sh is /bin/dash not /bin/bash.